### PR TITLE
Fixes the following issues per discussion https://community.home-assi…

### DIFF
--- a/flux_led/__init__.py
+++ b/flux_led/__init__.py
@@ -567,8 +567,8 @@ class WifiLedBulb():
 		self.turnOn(False)
 	
 	def getWarmWhite255(self):
-		if mode == "ww":
-			return int(self.raw_state[9])
+		if self.mode == "ww":
+			return int(self.raw_sate[9])
 		return 255
 
 	def setWarmWhite(self, level, persist=True):
@@ -588,7 +588,7 @@ class WifiLedBulb():
 		self.__write(msg)
 
 	def getRgb(self):
-		if mode == "color":
+		if self.mode == "color":
 			red = self.raw_sate[6]
 			green = self.raw_sate[7]
 			blue = self.raw_sate[8]

--- a/flux_led/__init__.py
+++ b/flux_led/__init__.py
@@ -454,7 +454,7 @@ class WifiLedBulb():
 		self.__state_str = ""
 		self.mode = ""
 		self.raw_state = None
-		#self.refreshState()
+		self.refreshState()
 
 	def __determineMode(self, ww_level, pattern_code):
 		mode = "unknown"


### PR DESCRIPTION
Fixes the following issues per discussion [https://community.home-assistant.io/t/magiclight-flux-wifi-color-led-light-component/2271/27](https://community.home-assistant.io/t/magiclight-flux-wifi-color-led-light-component/2271/27)

      ERROR:homeassistant.core:BusHandler:Exception doing job
      Traceback (most recent call last):
        File "/home/mdemello/devel/home-assistant/homeassistant/core.py", line 835, in job_handler
          func(arg)
        File "/home/mdemello/devel/home-assistant/homeassistant/helpers/event.py", line 179, in pattern_time_change_listener
          action(now)
        File "/home/mdemello/devel/home-assistant/homeassistant/helpers/entity_component.py", line 180, in _update_entity_states
          entity.update_ha_state(True)
        File "/home/mdemello/devel/home-assistant/homeassistant/helpers/entity.py", line 166, in update_ha_state
          attr = self.state_attributes or {}
        File "/home/mdemello/devel/home-assistant/homeassistant/components/light/__init__.py", line 281, in state_attributes
          value = getattr(self, prop)
        File "/home/mdemello/devel/home-assistant/homeassistant/components/light/flux_led.py", line 103, in brightness
          return self._bulb.getWarmWhite255()
        File "/home/mdemello/.homeassistant/deps/flux_led/__init__.py", line 570, in getWarmWhite255
          if mode == "ww":
      NameError: name 'mode' is not defined

      ERROR:homeassistant.core:BusHandler:Exception doing job
      Traceback (most recent call last):
        File "/home/mdemello/devel/home-assistant/homeassistant/core.py", line 835, in job_handler
          func(arg)
        File "/home/mdemello/devel/home-assistant/homeassistant/helpers/event.py", line 179, in pattern_time_change_listener
          action(now)
        File "/home/mdemello/devel/home-assistant/homeassistant/helpers/entity_component.py", line 180, in _update_entity_states
          entity.update_ha_state(True)
        File "/home/mdemello/devel/home-assistant/homeassistant/helpers/entity.py", line 166, in update_ha_state
          attr = self.state_attributes or {}
        File "/home/mdemello/devel/home-assistant/homeassistant/components/light/__init__.py", line 281, in state_attributes
          value = getattr(self, prop)
        File "/home/mdemello/devel/home-assistant/homeassistant/components/light/flux_led.py", line 108, in rgb_color
          return self._bulb.getRgb()
        File "/home/mdemello/.homeassistant/deps/flux_led/__init__.py", line 591, in getRgb
          if mode == "color":Turned
      NameError: name 'mode' is not defined