### PR TITLE
Adding brightness handling

### DIFF
--- a/flux_led/__init__.py
+++ b/flux_led/__init__.py
@@ -609,7 +609,7 @@ class WifiLedBulb():
         msg.append(0x0f)
         self.__write(msg)
         
-     def setRgbw(self, r,g,b,w, persist=True):
+    def setRgbw(self, r,g,b,w, persist=True):
         if persist:
             msg = bytearray([0x31])
         else:

--- a/flux_led/__init__.py
+++ b/flux_led/__init__.py
@@ -635,9 +635,9 @@ class WifiLedBulb():
             msg = bytearray([0x31])
         else:
             msg = bytearray([0x41])
-        msg.append(r)
-        msg.append(g)
-        msg.append(b)
+        msg.append(int(r))
+        msg.append(int(g))
+        msg.append(int(b))
         msg.append(0x00)
         msg.append(0xf0)
         msg.append(0x0f)

--- a/flux_led/__init__.py
+++ b/flux_led/__init__.py
@@ -602,7 +602,7 @@ class WifiLedBulb():
         else:
             msg = bytearray([0x41])
         msg.append(0x00)
-        msg.append(int(level)))
+        msg.append(int(level))
         msg.append(0x00)
         msg.append(int(level))
         msg.append(0x0f)

--- a/flux_led/__init__.py
+++ b/flux_led/__init__.py
@@ -602,9 +602,22 @@ class WifiLedBulb():
         else:
             msg = bytearray([0x41])
         msg.append(0x00)
-        msg.append(int(level))
+        msg.append(0x00)
         msg.append(0x00)
         msg.append(int(level))
+        msg.append(0x0f)
+        msg.append(0x0f)
+        self.__write(msg)
+        
+     def setRGBW(self, r,g,b,w, persist=True):
+        if persist:
+            msg = bytearray([0x31])
+        else:
+            msg = bytearray([0x41])
+        msg.append(int(r))
+        msg.append(int(g))
+        msg.append(int(b))
+        msg.append(int(w))
         msg.append(0x0f)
         msg.append(0x0f)
         self.__write(msg)

--- a/flux_led/__init__.py
+++ b/flux_led/__init__.py
@@ -602,7 +602,7 @@ class WifiLedBulb():
         else:
             msg = bytearray([0x41])
         msg.append(0x00)
-        msg.append(0x00)
+        msg.append(int(level)))
         msg.append(0x00)
         msg.append(int(level))
         msg.append(0x0f)

--- a/flux_led/__init__.py
+++ b/flux_led/__init__.py
@@ -609,7 +609,7 @@ class WifiLedBulb():
         msg.append(0x0f)
         self.__write(msg)
         
-     def setRGBW(self, r,g,b,w, persist=True):
+     def setRgbw(self, r,g,b,w, persist=True):
         if persist:
             msg = bytearray([0x31])
         else:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name = 'flux_led',
     packages = ['flux_led'],
-    version = '0.5',
+    version = '0.6',
     description = 'a library to communicate with the flux_led',
     url='https://github.com/Danielhiversen/flux_led',
     classifiers=[


### PR DESCRIPTION
By default, Flux LED don't support brightness So I added `__calculateBrightness()`  to simulate it. It works great for me.

I also modified `setRgb()` and `setRgbw()` to allow brightness to be set through those methods.

Please note, that the white component is not part of the brightness computation because I think there are many use cases, where it makes sense to set it separately. However, this may be a  subject for debate.