### PR TITLE
Updated Readme since flux_led.py does not exist anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,53 +45,53 @@ easy_install flux_led
 ##### Examples:
 ```
 Scan network:
-	flux_led.py -s
+	python -m flux_led -s
 
 Scan network and show info about all:
-	flux_led.py -sSti
+	python -m flux_led -sSti
 
 Turn on:
-	flux_led.py 192.168.1.100 --on
-	flux_led.py 192.168.1.100 -192.168.1.101 -1
+	python -m flux_led 192.168.1.100 --on
+	python -m flux_led 192.168.1.100 -192.168.1.101 -1
 
 Turn on all bulbs on LAN:
-	flux_led.py -sS --on
+	python -m flux_led -sS --on
 
 Turn off:
-	flux_led.py 192.168.1.100 --off
-	flux_led.py 192.168.1.100 --0
-	flux_led.py -sS --off
+	python -m flux_led 192.168.1.100 --off
+	python -m flux_led 192.168.1.100 --0
+	python -m flux_led -sS --off
 	
 Set warm white, 75%
-	flux_led.py 192.168.1.100 -w 75 -0	
+	python -m flux_led 192.168.1.100 -w 75 -0	
 
 Set fixed color red :
-	flux_led.py 192.168.1.100 -c Red
-	flux_led.py 192.168.1.100 -c 255,0,0
-	flux_led.py 192.168.1.100 -c "#FF0000"
+	python -m flux_led 192.168.1.100 -c Red
+	python -m flux_led 192.168.1.100 -c 255,0,0
+	python -m flux_led 192.168.1.100 -c "#FF0000"
 	
 Set preset pattern #35 with 40% speed:	
-	flux_led.py 192.168.1.100 -p 35 40
+	python -m flux_led 192.168.1.100 -p 35 40
 	
 Set custom pattern 25% speed, red/green/blue, gradual change:
-	flux_led.py 192.168.1.100 -C gradual 25 "red green (0,0,255)"
+	python -m flux_led 192.168.1.100 -C gradual 25 "red green (0,0,255)"
 
 Sync all bulb's clocks with this computer's:
-	flux_led.py -sS --setclock
+	python -m flux_led -sS --setclock
 		
 Set timer #1 to turn on red at 5:30pm on weekdays:
-	flux_led.py 192.168.1.100 -T 1 color "time:1730;repeat:12345;color:red"
+	python -m flux_led 192.168.1.100 -T 1 color "time:1730;repeat:12345;color:red"
 	
 Deactivate timer #4:
-	flux_led.py 192.168.1.100 -T 4 inactive ""
+	python -m flux_led 192.168.1.100 -T 4 inactive ""
 
 Use --timerhelp for more details on setting timers
 ```
 	
 ##### Show help:
 ```	
-$ ./flux_led.py -h
-Usage: usage: flux_led.py [-sS10cwpCiltThe] [addr1 [addr2 [addr3] ...].
+$ python -m flux_led -h
+Usage: usage: __main__.py [-sS10cwpCiltThe] [addr1 [addr2 [addr3] ...].
 
 A utility to control Flux WiFi LED Bulbs.
 


### PR DESCRIPTION
This PR updates the README instructions by replacing the `flux_led.py`  by `python -m flux_led`  since it was removed from this repo. 

We can create a command line script in the future to make it easier when running it directly. 

This PR fixes first item mentioned at https://github.com/Danielhiversen/flux_led/issues/15
