### PR TITLE
added some extra hacky code that causes it to work with both my strip…

### DIFF
--- a/flux_led/__main__.py
+++ b/flux_led/__main__.py
@@ -497,7 +497,7 @@ class LedTimer():
         return txt
 
 class WifiLedBulb():
-    def __init__(self, ipaddr, verbose=False, port=5577, timeout=5 ):
+    def __init__(self, ipaddr, port=5577, timeout=5, verbose=False):
         self.ipaddr = ipaddr
         self.port = port
         self.timeout = timeout
@@ -521,8 +521,6 @@ class WifiLedBulb():
 
         self.connect(2)
         self.update_state()
-        
-
 
 
     @property
@@ -958,7 +956,7 @@ class WifiLedBulb():
         # Some devices provide RGBW control, but require two separate writes
         # If we've been given both colours and whites, split them up
         if self.badrgbw == True and (r != None and (w != None or w2 != None)):
-            self.setRgbw(w=w, retry=retry, persist=persist, w2=w2)
+            self.setRgbw(w=w, w2=w2, retry=retry, persist=persist)
             self.setRgbw(r, g, b, retry=retry, persist=persist)
             return
 
@@ -976,7 +974,7 @@ class WifiLedBulb():
             # all other devices
             # determine how to set the special byte
             # For devices that can't set RGB+W simultaneously, indicate whether
-            # we should set the white outputs or the RGB outputs.
+            # we should set the white outputs or the RGB outputs
             if not self.rgbwprotocol:
                 if w is not None or w2 is not None:
                     special = 0x0f
@@ -1027,7 +1025,7 @@ class WifiLedBulb():
             
             # Message terminator
             msg.append(0x0f)
-            
+
         self.dbgPrint("Generated Color Command: ")
         self.dbgPrint("    R-" + str(r) + " G-" + str(g) + " B-" + str(b) + " WW-" + str(w) + " CW-" + str(w2))
         # send the message
@@ -1807,7 +1805,7 @@ def main():
         except Exception as e:
             print("Unable to connect to bulb at [{}]: {}".format(info['ipaddr'],e))
             continue
-            
+
         if options.getclock:
             print("{} [{}] {}".format(info['id'], info['ipaddr'],bulb.getClock()))
 
@@ -1876,7 +1874,7 @@ def main():
                 num += 1
                 print("  Timer #{}: {}".format(num, t))
             print("")
-        
+
     sys.exit(0)
 
 


### PR DESCRIPTION
I have the following device: 
https://www.amazon.com/gp/product/B01DY56N8U/ref=oh_aui_detailpage_o01_s00?ie=UTF8&psc=1

It shows up as having "V1" firmware in the Magic Home app. 

A packet capture shows an additional byte is sent during color and rgb updates:

    0x31 0x00 0x00 0x00 W 0x00 0x0F 0x0F CSUM
    or
    0x31 R G B 0x00 0x00 0xF0 0x0F CSUM

At present, I am triggering adding the (apparently) extra byte for the V1 RGBW is triggered by the same conditions as the "BadRGBW", which happens to be what the problematic device above registers as. I am unsure if this is the only device which gets the "BadRGBW" classification. I also did not immedeately see any indication of determining the V1 vs. V3 firmware version in the packets exchanged. 

I've got one commit in my forked repo where I have the color setting and white intensity setting working for both my strips (the other is https://www.amazon.com/gp/product/B01JZ2SI6Q/ref=oh_aui_detailpage_o02_s00?ie=UTF8&psc=1). 

Since I'm somewhat new around here... What would be the desired path forward for integrating such changes?

