### PR TITLE
Support 9-byte command protocol for 0x8125

### DIFF
--- a/flux_led/__main__.py
+++ b/flux_led/__main__.py
@@ -59,7 +59,7 @@ class utils:
         global webcolors_available
 
         # see if it's already a color tuple
-        if type(color) is tuple and (len(color) >= 3 and len(color) <= 5):
+        if type(color) is tuple and len(color) in [3, 4, 5]:
             return color
 
         # can't convert non-string
@@ -87,7 +87,7 @@ class utils:
         # try to convert a string RGB tuple
         try:
             val = ast.literal_eval(color)
-            if type(val) is not tuple or len(val) < 3 or len(val) > 5:
+            if type(val) is not tuple or len(val) not in [3, 4, 5]:
                 raise Exception
             return val
         except:

--- a/tests.py
+++ b/tests.py
@@ -291,6 +291,67 @@ class TestLight(unittest.TestCase):
 
     @patch('flux_led.WifiLedBulb._send_msg')
     @patch('flux_led.WifiLedBulb._read_msg')
+    def test_rgbwwcw(self, mock_read, mock_send):
+        calls = 0
+        def read_data(expected):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                self.assertEqual(expected, 2)
+                return bytearray(b'\x81D')
+            if calls == 2:
+                self.assertEqual(expected, 14)
+                return bytearray(b'\x81\x25\x23\x61\x21\x10\xb6\x00\x98\x00\x04\x00\xf0\xbc')
+            if calls == 3:
+                self.assertEqual(expected, 14)
+                return bytearray(b'\x81\x25\x23\x61\x21\x10\xb6\x00\x98\x19\x04\x25\x0f\xa6')
+
+        mock_read.side_effect = read_data
+        light = flux_led.WifiLedBulb("192.168.1.164")
+        self.assertEqual(mock_read.call_count, 2)
+        self.assertEqual(mock_send.call_count, 2)
+        self.assertEqual(
+            mock_send.call_args,
+            mock.call(bytearray(b'\x81\x8a\x8b'))
+        )
+
+        self.assertEqual(light.protocol, 'LEDENET')
+        self.assertEqual(light.is_on, True)
+        self.assertEqual(light.mode, "color")
+        self.assertEqual(light.warm_white, 0)
+        self.assertEqual(light.brightness, 182)
+        self.assertEqual(light.getRgb(), (182, 0, 152))
+        self.assertEqual(light.rgbwcapable, True)
+        self.assertEqual(light.__str__(), "ON  [Color: (182, 0, 152) White: 0 raw state: 129,37,35,97,33,16,182,0,152,0,4,0,240,188,]")
+
+        light.setWarmWhite255(25)
+        self.assertEqual(mock_read.call_count, 2)
+        self.assertEqual(mock_send.call_count, 3)
+        self.assertEqual(
+            mock_send.call_args,
+            mock.call(bytearray(b'1\x00\x00\x00\x19\x19\x0f\x0f'))
+        )
+
+        light.update_state()
+        self.assertEqual(mock_read.call_count, 3)
+        self.assertEqual(mock_send.call_count, 4)
+        self.assertEqual(
+            mock_send.call_args,
+            mock.call(bytearray(b'\x81\x8a\x8b'))
+        )
+
+        self.assertEqual(light.protocol, 'LEDENET')
+        self.assertEqual(light.is_on, True)
+        self.assertEqual(light.mode, "color")
+        self.assertEqual(light.warm_white, 25)
+        self.assertEqual(light.cold_white, 37)
+        self.assertEqual(light.brightness, 182)
+        self.assertEqual(light.getRgbww(), (182, 0, 152, 25, 37))
+        self.assertEqual(light.rgbwcapable, True)
+        self.assertEqual(light.__str__(), "ON  [Color: (182, 0, 152) White: 25 raw state: 129,37,35,97,33,16,182,0,152,25,4,37,15,166,]")
+
+    @patch('flux_led.WifiLedBulb._send_msg')
+    @patch('flux_led.WifiLedBulb._read_msg')
     def test_original_ledenet(self, mock_read, mock_send):
         calls = 0
         def read_data(expected):

--- a/tests.py
+++ b/tests.py
@@ -141,7 +141,7 @@ class TestLight(unittest.TestCase):
             mock.call(bytearray(b'\x81\x8a\x8b'))
         )
 
-        self.assertEqual(light.__str__(), "False [Warm White: 65% raw state: 129,68,36,97,33,16,0,0,0,166,4,0,15,52,]")
+        self.assertEqual(light.__str__(), "OFF  [Warm White: 65% raw state: 129,68,36,97,33,16,0,0,0,166,4,0,15,52,]")
         self.assertEqual(light.protocol, None)
         self.assertEqual(light.is_on, False)
         self.assertEqual(light.mode, "ww")
@@ -236,7 +236,7 @@ class TestLight(unittest.TestCase):
             mock_send.call_args,
             mock.call(bytearray(b'\x81\x8a\x8b'))
         )
-        self.assertEqual(light.__str__(), "False [Color: (255, 91, 212) Brightness: 255 raw state: 129,68,36,97,33,16,255,91,212,0,4,0,240,157,]")
+        self.assertEqual(light.__str__(), "OFF  [Color: (255, 91, 212) Brightness: 255 raw state: 129,68,36,97,33,16,255,91,212,0,4,0,240,157,]")
         self.assertEqual(light.protocol, None)
         self.assertEqual(light.is_on, False)
         self.assertEqual(light.mode, "color")
@@ -251,7 +251,7 @@ class TestLight(unittest.TestCase):
             mock_send.call_args,
             mock.call(bytearray(b'q#\x0f'))
         )
-        self.assertEqual(light.__str__(), "False [Color: (255, 91, 212) Brightness: 255 raw state: 129,68,36,97,33,16,255,91,212,0,4,0,240,157,]")
+        self.assertEqual(light.__str__(), "OFF  [Color: (255, 91, 212) Brightness: 255 raw state: 129,68,36,97,33,16,255,91,212,0,4,0,240,157,]")
         self.assertEqual(light.protocol, None)
         self.assertEqual(light.is_on, True)
         self.assertEqual(light.mode, "color")
@@ -266,7 +266,7 @@ class TestLight(unittest.TestCase):
             mock_send.call_args,
             mock.call(bytearray(b'1\x03M\xf7\x00\xf0\x0f'))
         )
-        self.assertEqual(light.__str__(), "False [Color: (255, 91, 212) Brightness: 255 raw state: 129,68,36,97,33,16,255,91,212,0,4,0,240,157,]")
+        self.assertEqual(light.__str__(), "OFF  [Color: (255, 91, 212) Brightness: 255 raw state: 129,68,36,97,33,16,255,91,212,0,4,0,240,157,]")
         self.assertEqual(light.protocol, None)
         self.assertEqual(light.is_on, True)
         self.assertEqual(light.mode, "color")
@@ -366,7 +366,7 @@ class TestLight(unittest.TestCase):
             mock.call(bytearray(b'\xef\x01w'))
         )
 
-        self.assertEqual(light.__str__(), 'False [Color: (1, 25, 80) Brightness: 80 raw state: 102,1,36,65,33,8,1,25,80,1,153,]')
+        self.assertEqual(light.__str__(), 'OFF  [Color: (1, 25, 80) Brightness: 80 raw state: 102,1,36,65,33,8,1,25,80,1,153,]')
         self.assertEqual(light.protocol, 'LEDENET_ORIGINAL')
         self.assertEqual(light.is_on, False)
         self.assertEqual(light.mode, "color")


### PR DESCRIPTION
Resolves #44 

Based on my collaboration w/ @gerth2 (see his PR #42) I've implemented support for 0x8125 controllers that we both have. There's inspirations from his PR to be found in mine (especially the command-line stuff), as well as a simplification of the protocol handling.

@mjg59 please have a look and let me know if I'm on the right track. I was trying to keep this pull request clean, yet still clean up some logic.

I've tested it on my controller and it's behaving as expected so far.

My type of controller looks like this: https://www.amazon.com/gp/product/B01DY56N8U