### PR TITLE
Always close and reconnect the socket when updating or querying state

### DIFF
--- a/flux_led/__main__.py
+++ b/flux_led/__main__.py
@@ -452,7 +452,7 @@ class LedTimer():
     def __str__(self):
         txt = ""
         if not self.active:
-          return "Unset"
+            return "Unset"
 
         if self.turn_on:
             txt += "[ON ]"
@@ -613,7 +613,6 @@ class WifiLedBulb():
             self._use_csum = True
         if rx == None and retry > 0:
             self._determine_query_len(max(retry -1,0))
-
         
  
     def query_state(self, retry=2, led_type = None):
@@ -628,6 +627,7 @@ class WifiLedBulb():
             led_type = 'LEDENET_ORIGINAL'
 
         try:
+            self.connect()
             self._send_msg(msg)
             rx = self._read_msg(self._query_len)
         except socket.error:
@@ -642,7 +642,6 @@ class WifiLedBulb():
                 return rx
             return self.query_state(max(retry-1, 0), led_type)
         return rx
-
 
 
     def update_state(self, retry=2 ):
@@ -718,7 +717,6 @@ class WifiLedBulb():
         if mode == "unknown":
             if retry < 1:
                 return
-            self.connect()
             self.update_state(max(retry-1, 0))
             return
         power_state = rx[2]
@@ -1016,6 +1014,8 @@ class WifiLedBulb():
             csum = sum(bytes) & 0xFF
             bytes.append(csum)
         with self._lock:
+            # print("Sending: ")
+            # utils.dump_bytes(bytes)
             self._socket.send(bytes)
 
     def _read_msg(self, expected):
@@ -1037,6 +1037,8 @@ class WifiLedBulb():
                 pass
             finally:
                 self._socket.setblocking(1)
+        # print("Read: ")
+        # utils.dump_bytes(rx)
         return rx
 
     def getClock(self):

--- a/flux_led/__main__.py
+++ b/flux_led/__main__.py
@@ -1014,8 +1014,6 @@ class WifiLedBulb():
             csum = sum(bytes) & 0xFF
             bytes.append(csum)
         with self._lock:
-            # print("Sending: ")
-            # utils.dump_bytes(bytes)
             self._socket.send(bytes)
 
     def _read_msg(self, expected):
@@ -1037,8 +1035,6 @@ class WifiLedBulb():
                 pass
             finally:
                 self._socket.setblocking(1)
-        # print("Read: ")
-        # utils.dump_bytes(rx)
         return rx
 
     def getClock(self):


### PR DESCRIPTION
Through investigating issue with flux_led and home-assistant where state was not correctly reported hass issue: https://github.com/home-assistant/home-assistant/issues/11565 it became clear something a socket level wasn't working. Hence issue against flux_led #51 raised.

Tracing of the raw bytes sent and received showed that if update_state is called often then the raw data returned reports the correct state, if however calls are further apart, then the data returned appears to be stale.

Extending/changing timeouts did not impact the behaviour.  Only closing and recreating the socket appears to be a reliable means of fixing this issue. The problem with the socket that requires this reconnect isn't apparent, are raised (or caught) when trying to read and write the socket which returns this inaccurate/stale data.

- [x] pytests test.py ran sucessfully
- [x] testing performed with standalone module
- [x] testing performed with Home-Assistant calling changed module.
- [x] tested on a range of wifi LED controllers as listed in issue #51 