### PR TITLE
setWarmWhite255 no longer includes cold white by explicitly setting w2=0

### DIFF
--- a/flux_led/__main__.py
+++ b/flux_led/__main__.py
@@ -818,7 +818,7 @@ class WifiLedBulb():
         self.setWarmWhite255(utils.percentToByte(level), persist, retry)
 
     def setWarmWhite255(self, level, persist=True, retry=2):
-        self.setRgbw(w=level, persist=persist, brightness=None, retry=retry)
+        self.setRgbw(w=level, persist=persist, brightness=None, retry=retry, w2=0)
 
     def setColdWhite(self, level, persist=True, retry=2):
         self.setColdWhite255(utils.percentToByte(level), persist, retry)


### PR DESCRIPTION
Hi Daniel! Great work on reverse engineering. This commit fixes the bug where warm white also includes cold white. It wasn't a protocol issue but a simple bug. setWarmWhite255 calls self.setRgbw without specifying w2, so it defaults to None, which the setRgbw function treats as Value Missing and then outputs the w value for w2! By explicitly specifying w2=0 the problem goes away, and true warm white is achieved.