### PR TITLE
Support for RGBW device MagicHome ZJ-WFMN-E

### DIFF
--- a/flux_led/__main__.py
+++ b/flux_led/__main__.py
@@ -698,7 +698,8 @@ class WifiLedBulb():
             rx[1] == 0x25 or
             rx[1] == 0x33 or
             rx[1] == 0x81 or
-            rx[1] == 0x44):
+            rx[1] == 0x44 or
+            rx[1] == 0x06):
             self.rgbwcapable = True
 
         # Devices that use an 8-byte protocol


### PR DESCRIPTION
Support for MagicHome controller with RGBW and IR. Like LC04, but with a non-ESP chip, PCB code ZJ-WFMN-E. E.g. on https://de.aliexpress.com/item/33060750692.html.

