### PR TITLE
Add version_num and preset_pattern_num property

### DIFF
--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -86,6 +86,17 @@ class LEDENETDevice:
         return self.raw_state.model_num if self.raw_state else None
 
     @property
+    def version_num(self):
+        """Return the version number."""
+        raw_state = self.raw_state
+        return raw_state.version_number if hasattr(raw_state, "version_number") else 1
+
+    @property
+    def preset_pattern_num(self):
+        """Return the preset pattern number."""
+        return self.raw_state.preset_pattern
+
+    @property
     def rgbwprotocol(self):
         """Devices that don't require a separate rgb/w bit."""
         return self.model_num in RGBW_PROTOCOL_MODELS

--- a/tests.py
+++ b/tests.py
@@ -113,6 +113,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.brightness, 80)
         self.assertEqual(light.getRgb(), (1, 25, 80))
         self.assertEqual(light.device_type, flux_led.DeviceType.Bulb)
+        self.assertEqual(light.version_num, 4)
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")
@@ -567,6 +568,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.warm_white, 0)
         self.assertEqual(light.brightness, 80)
         self.assertEqual(light.getRgb(), (1, 25, 80))
+        self.assertEqual(light.version_num, 1)
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")


### PR DESCRIPTION
- We want to avoid having external callers accessing the
  raw state since we may change how the internals work
  in the future.