### PR TITLE
Support CCT mode when RGBWW is supported

### DIFF
--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -104,6 +104,21 @@ class LEDENETDevice:
         )
 
     @property
+    def color_temp(self):
+        """Return the current color temp in kelvin."""
+        return (self.getWhiteTemperature())[0]
+
+    @property
+    def min_temp(self):
+        """Returns the minimum color temp in kelvin."""
+        return MIN_TEMP
+
+    @property
+    def max_temp(self):
+        """Returns the maximum color temp in kelvin."""
+        return MAX_TEMP
+
+    @property
     def _rgbwwprotocol(self):
         """Device that uses the 9-byte protocol."""
         return self._uses_9byte_protocol(self.model_num)
@@ -131,6 +146,18 @@ class LEDENETDevice:
     @property
     def color_modes(self):
         """The available color modes."""
+        color_modes = self._internal_color_modes
+        # We support CCT mode if the device supports RGBWW
+        # but we do not add it to internal color modes as
+        # we need to distingush between devices that are RGB/CCT
+        # and ones that are RGB&CCT
+        if COLOR_MODE_RGBWW in color_modes and COLOR_MODE_CCT not in color_modes:
+            return {COLOR_MODE_CCT, *color_modes}
+        return color_modes
+
+    @property
+    def _internal_color_modes(self):
+        """The internal available color modes."""
         model_db_entry = MODEL_MAP.get(self.model_num)
         if not model_db_entry:
             # Default mode is RGB
@@ -142,8 +169,9 @@ class LEDENETDevice:
     @property
     def color_mode(self):
         """The current color mode."""
-        color_modes = self.color_modes
+        color_modes = self._internal_color_modes
         if COLOR_MODE_RGBWW in color_modes and not self.color_active:
+            # We support CCT mode if the device supports RGBWW
             return COLOR_MODE_CCT
         if (
             color_modes == COLOR_MODES_RGB_CCT

--- a/tests.py
+++ b/tests.py
@@ -415,7 +415,7 @@ class TestLight(unittest.TestCase):
 
         mock_read.side_effect = read_data
         light = flux_led.WifiLedBulb("192.168.1.164")
-        assert light.color_modes == {COLOR_MODE_RGBWW}
+        assert light.color_modes == {COLOR_MODE_RGBWW, COLOR_MODE_CCT}
 
         self.assertEqual(mock_read.call_count, 2)
         self.assertEqual(mock_send.call_count, 1)
@@ -725,7 +725,7 @@ class TestLight(unittest.TestCase):
 
         mock_read.side_effect = read_data
         switch = flux_led.WifiLedBulb("192.168.1.164")
-        assert switch.color_modes == {COLOR_MODE_RGBWW}
+        assert switch.color_modes == {COLOR_MODE_RGBWW, COLOR_MODE_CCT}
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")


### PR DESCRIPTION
We present the color_mode as CCT when the RGB channels are
off if the device supports RGBWW. We should include CCT
mode in color_modes so consumers of the api are aware that
the mode is available and will not be suprised when it is
presented.