### PR TITLE
Fix fallback to old ledenet protocol with asyncio

### DIFF
--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -166,12 +166,12 @@ class AIOWifiLedBulb(LEDENETDevice):
                         self._data_future, timeout=self.timeout
                     )
                 except asyncio.TimeoutError:
-                    self.close()
+                    self._aio_protocol.close()
                     continue
                 if not protocol.is_valid_state_response(full_msg):
                     # We just sent a garage query which the old procotol
                     # cannot process, recycle the connection
-                    self.close()
+                    self._aio_protocol.close()
                     continue
                 # Devices that use an 9-byte protocol
                 if self._uses_9byte_protocol(full_msg[1]):


### PR DESCRIPTION
Fixes

```
2021-10-13 20:41:47 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Fairy Lights for flux_led
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/tasks.py", line 492, in wait_for
    fut.result()
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/flux_led/aiodevice.py", line 165, in _async_determine_protocol
    full_msg = await asyncio.wait_for(
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/tasks.py", line 494, in wait_for
    raise exceptions.TimeoutError() from exc
asyncio.exceptions.TimeoutError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/config_entries.py", line 304, in async_setup
    result = await component.async_setup_entry(hass, self)  # type: ignore
  File "/Users/bdraco/home-assistant/homeassistant/components/flux_led/__init__.py", line 146, in async_setup_entry
    await device.async_setup(_async_state_changed)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/flux_led/aiodevice.py", line 44, in async_setup
    await self._async_determine_protocol()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/flux_led/aiodevice.py", line 169, in _async_determine_protocol
    self.close()
AttributeError: 'AIOWifiLedBulb' object has no attribute 'close'

```