### PR TITLE
Add workaround for devices that sometimes push the wrong power state

### DIFF
--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -51,12 +51,12 @@ class AIOWifiLedBulb(LEDENETDevice):
     async def async_turn_on(self):
         """Turn on the device."""
         await self._async_send_msg(self._protocol.construct_state_change(True))
-        self._set_power_state(self._protocol.on_byte)
+        self._set_power_state_ignore_next_push(self._protocol.on_byte)
 
     async def async_turn_off(self):
         """Turn off the device."""
         await self._async_send_msg(self._protocol.construct_state_change(False))
-        self._set_power_state(self._protocol.off_byte)
+        self._set_power_state_ignore_next_push(self._protocol.off_byte)
 
     async def async_set_white_temp(self, temperature, brightness, persist=True):
         """Set the white tempature."""

--- a/flux_led/const.py
+++ b/flux_led/const.py
@@ -70,3 +70,11 @@ STATE_VERSION_NUMBER = "version_number"
 STATE_COOL_WHITE = "cool_white"
 STATE_COLOR_MODE = "color_mode"
 STATE_CHECK_SUM = "check_sum"
+
+CHANNEL_STATES = {
+    STATE_RED,
+    STATE_GREEN,
+    STATE_BLUE,
+    STATE_WARM_WHITE,
+    STATE_COOL_WHITE,
+}


### PR DESCRIPTION
    
    - These devices sometimes send the wrong power state.
    
      We can detect this since we are tracking
      the power state via the previous message and know when the bug
      presents which allows us to correct the state.