### PR TITLE
Add models for "Goldwin Smart Single Color LED Strip Lights WiFi

### DIFF
--- a/flux_led/models_db.py
+++ b/flux_led/models_db.py
@@ -252,7 +252,7 @@ MODELS = [
     ),
     LEDENETModel(
         model_num=0x21,
-        models=[],
+        models=["AK001-ZJ2101", "AK001-ZJ2104"],
         description="Smart Bulb Dimmable",
         always_writes_white_and_colors=False,  # Formerly rgbwprotocol
         nine_byte_read_protocol=False,


### PR DESCRIPTION
Controller Compatible with Amazon Alexa and Google Assistant Fit for
5050,5630,3528,5730,5054 LED Strip Lights and Panel Lights Wireless
Remote"
(https://smile.amazon.com/gp/product/B07JB5N3Y7)