### PR TITLE
Add model and version to discovery info

### DIFF
--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -39,6 +39,7 @@ class AIOBulbScanner(BulbScanner):
         """Send the scans."""
         _LOGGER.debug("discover: %s => %s", destination, self.DISCOVER_MESSAGE)
         transport.sendto(self.DISCOVER_MESSAGE, destination)
+        transport.sendto(self.VERSION_MESSAGE, destination)
         quit_time = time.monotonic() + timeout
         remain_time = timeout
         while True:
@@ -55,6 +56,7 @@ class AIOBulbScanner(BulbScanner):
                 # No response, send broadcast again in cast it got lost
                 _LOGGER.debug("discover: %s => %s", destination, self.DISCOVER_MESSAGE)
                 transport.sendto(self.DISCOVER_MESSAGE, destination)
+                transport.sendto(self.VERSION_MESSAGE, destination)
             else:
                 return  # found_all
             remain_time = quit_time - time.monotonic()
@@ -85,5 +87,5 @@ class AIOBulbScanner(BulbScanner):
         finally:
             transport.close()
 
-        self.found_bulbs = response_list.values()
+        self.found_bulbs = self._found_bulbs(response_list)
         return list(self.found_bulbs)

--- a/flux_led/const.py
+++ b/flux_led/const.py
@@ -11,6 +11,15 @@ class LevelWriteMode(Enum):
 
 PRESET_MUSIC_MODE = 0x62
 
+ATTR_IPADDR = "ipaddr"
+ATTR_ID = "id"
+ATTR_MODEL = "model"
+ATTR_MODEL_NUM = "model_num"
+ATTR_VERSION_NUM = "version_num"
+ATTR_FIRMWARE_DATE = "firmware_date"
+ATTR_MODEL_INFO = "model_info"
+ATTR_MODEL_DESCRIPTION = "model_description"
+
 # Color modes
 COLOR_MODE_DIM = "DIM"
 COLOR_MODE_CCT = "CCT"

--- a/flux_led/models_db.py
+++ b/flux_led/models_db.py
@@ -525,3 +525,8 @@ RGBW_PROTOCOL_MODELS = {
 USE_9BYTE_PROTOCOL_MODELS = {
     model.model_num for model in MODELS if model.protocol == PROTOCOL_LEDENET_9BYTE
 }
+
+
+def get_model_description(model_num):
+    """Return the description for a model."""
+    return MODEL_DESCRIPTIONS.get(model_num, f"Unknown Model {hex(model_num)}")

--- a/flux_led/models_db.py
+++ b/flux_led/models_db.py
@@ -122,7 +122,7 @@ MODELS = [
     LEDENETModel(
         model_num=0x06,
         models=["AK001-ZJ2147"],
-        description="Magic Home Branded RGBW Controller",
+        description="RGBW Controller",
         always_writes_white_and_colors=False,  # Formerly rgbwprotocol
         protocol=PROTOCOL_LEDENET_8BYTE,
         mode_to_color_mode=GENERIC_RGBW_MAP,
@@ -132,7 +132,7 @@ MODELS = [
     LEDENETModel(
         model_num=0x07,
         models=[],
-        description="Magic Home Branded RGBCW Controller",
+        description="RGBCW Controller",
         always_writes_white_and_colors=False,  # Formerly rgbwprotocol
         protocol=PROTOCOL_LEDENET_9BYTE,
         mode_to_color_mode=GENERIC_RGBWW_MAP,
@@ -142,7 +142,7 @@ MODELS = [
     LEDENETModel(
         model_num=0x08,
         models=[],
-        description="Magic Home Branded RGB Controller with MIC",
+        description="RGB Controller with MIC",
         always_writes_white_and_colors=True,  # Formerly rgbwprotocol
         protocol=PROTOCOL_LEDENET_8BYTE,
         mode_to_color_mode=GENERIC_RGB_MAP,
@@ -297,7 +297,7 @@ MODELS = [
     LEDENETModel(
         model_num=0x33,
         models=["AK001-ZJ2145", "AK001-ZJ2146"],
-        description="Magic Home Branded RGB Controller",
+        description="RGB Controller",
         always_writes_white_and_colors=True,  # Formerly rgbwprotocol
         protocol=PROTOCOL_LEDENET_8BYTE,
         mode_to_color_mode=GENERIC_RGB_MAP,
@@ -317,7 +317,7 @@ MODELS = [
     LEDENETModel(
         model_num=0x41,
         models=[],
-        description="Magic Home Branded Single Channel Controller",
+        description="Single Channel Controller",
         always_writes_white_and_colors=False,  # Formerly rgbwprotocol
         protocol=PROTOCOL_LEDENET_8BYTE,
         mode_to_color_mode={},  # Only mode should be 0x41
@@ -372,7 +372,7 @@ MODELS = [
     LEDENETModel(
         model_num=0x62,
         models=[],
-        description="Magic Home Controller CCT",
+        description="CCT Controller",
         always_writes_white_and_colors=False,  # Formerly rgbwprotocol
         protocol=PROTOCOL_LEDENET_8BYTE,
         mode_to_color_mode={},
@@ -447,7 +447,7 @@ MODELS = [
     LEDENETModel(
         model_num=0xA1,
         models=[],
-        description="RGB Symphony [Addressable]",  # https://github.com/Danielhiversen/flux_led/pull/59/files#diff-09e60df19b61f5ceb8d2aef0ade582c2b84979cab660baa27c1ec65725144d76R776
+        description="RGB Symphony Original",  # https://github.com/Danielhiversen/flux_led/pull/59/files#diff-09e60df19b61f5ceb8d2aef0ade582c2b84979cab660baa27c1ec65725144d76R776
         always_writes_white_and_colors=False,
         protocol=PROTOCOL_LEDENET_ORIGINAL_ADDRESSABLE,
         mode_to_color_mode={},
@@ -457,7 +457,7 @@ MODELS = [
     LEDENETModel(
         model_num=0xA2,
         models=["AK001-ZJ2104"],
-        description="RGB Symphony [Addressable]",
+        description="RGB Symphony 2",
         always_writes_white_and_colors=False,
         protocol=PROTOCOL_LEDENET_ADDRESSABLE,
         mode_to_color_mode={},
@@ -467,7 +467,7 @@ MODELS = [
     LEDENETModel(
         model_num=0xA3,
         models=["K001-ZJ2148"],
-        description="Magic Home Branded RGB Symphony [Addressable]",
+        description="RGB Symphony 3",
         always_writes_white_and_colors=False,
         protocol=PROTOCOL_LEDENET_ADDRESSABLE,
         mode_to_color_mode={},

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -13,6 +13,18 @@ else:
 
 from .models_db import get_model_description
 
+from .const import (
+    ATTR_IPADDR,
+    ATTR_ID,
+    ATTR_MODEL,
+    ATTR_MODEL_NUM,
+    ATTR_VERSION_NUM,
+    ATTR_FIRMWARE_DATE,
+    ATTR_MODEL_INFO,
+    ATTR_MODEL_DESCRIPTION,
+)
+
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -27,9 +39,9 @@ def _process_discovery_message(data, decoded_data):
     ipaddr = data_split[0]
     data.update(
         {
-            "ipaddr": ipaddr,
-            "id": data_split[1],
-            "model": data_split[2],
+            ATTR_IPADDR: ipaddr,
+            ATTR_ID: data_split[1],
+            ATTR_MODEL: data_split[2],
         }
     )
 
@@ -44,16 +56,16 @@ def _process_version_message(data, decoded_data):
     if len(data_split) < 2:
         return
     try:
-        data["model_num"] = int(data_split[0], 16)
-        data["version_num"] = int(data_split[1], 16)
+        data[ATTR_MODEL_NUM] = int(data_split[0], 16)
+        data[ATTR_VERSION_NUM] = int(data_split[1], 16)
     except ValueError:
         return
-    data["model_description"] = get_model_description(data["model_num"])
+    data[ATTR_MODEL_DESCRIPTION] = get_model_description(data[ATTR_MODEL_NUM])
     if len(data_split) < 3:
         return
     firmware_date = data_split[2]
     try:
-        data["firmware_date"] = date(
+        data[ATTR_FIRMWARE_DATE] = date(
             int(firmware_date[:4]),
             int(firmware_date[4:6]),
             int(firmware_date[6:8]),
@@ -62,7 +74,7 @@ def _process_version_message(data, decoded_data):
         return
     if len(data_split) < 4:
         return
-    data["model_info"] = data_split[3]
+    data[ATTR_MODEL_INFO] = data_split[3]
 
 
 class FluxLEDDiscovery(TypedDict):
@@ -129,7 +141,7 @@ class BulbScanner:
         self._process_data(from_address, decoded_data, response_list)
         if address is None:
             return False
-        return response_list.get(address, {}).get("model_num") is not None
+        return response_list.get(address, {}).get(ATTR_MODEL_NUM) is not None
 
     def _process_data(self, from_address, decoded_data, response_list):
         """Process data."""
@@ -143,7 +155,7 @@ class BulbScanner:
     def _found_bulbs(self, response_list):
         """Return only complete bulb discoveries."""
 
-        return [info for info in response_list.values() if info.get("ipaddr")]
+        return [info for info in response_list.values() if info.get(ATTR_IPADDR)]
 
     def scan(self, timeout=10, address=None):
         """Scan for bulbs.

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -81,7 +81,9 @@ class FluxLEDDiscovery(TypedDict):
 class BulbScanner:
 
     DISCOVERY_PORT = 48899
-    BROADCAST_FREQUENCY = 4
+    BROADCAST_FREQUENCY = (
+        5  # At least 5 for A1 models (Magic Home Branded RGB Symphony [Addressable])
+    )
     RESPONSE_SIZE = 64
     DISCOVER_MESSAGE = b"HF-A11ASSISTHREAD"
     VERSION_MESSAGE = b"AT+LVER\r"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requirements = [
     "wheel>=0.34.2",
 ]
 
-requirements = ["webcolors", 'typing_extensions.zoneinfo;python_version<"3.8"']
+requirements = ["webcolors", 'typing_extensions;python_version<"3.8"']
 
 
 extra_requirements = {

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,7 @@ dev_requirements = [
     "wheel>=0.34.2",
 ]
 
-requirements = [
-    "webcolors"
-    'typing_extensions.zoneinfo;python_version<"3.8"'
-]
+requirements = ["webcolors", 'typing_extensions.zoneinfo;python_version<"3.8"']
 
 
 extra_requirements = {

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ dev_requirements = [
     "wheel>=0.34.2",
 ]
 
-requirements = ["webcolors"]
+requirements = [
+    "webcolors"
+    'typing_extensions.zoneinfo;python_version<"3.8"'
+]
 
 
 extra_requirements = {

--- a/tests.py
+++ b/tests.py
@@ -874,7 +874,7 @@ class TestLight(unittest.TestCase):
         light = flux_led.WifiLedBulb("192.168.1.164")
         self.assertEqual(light.model_num, 0x41)
         self.assertEqual(
-            light.model, "Magic Home Branded Single Channel Controller (0x41)"
+            light.model, "Single Channel Controller (0x41)"
         )
         assert light.color_modes == {COLOR_MODE_DIM}
 
@@ -974,7 +974,7 @@ class TestLight(unittest.TestCase):
         light = flux_led.WifiLedBulb("192.168.1.164")
         self.assertEqual(light.addressable, True)
         self.assertEqual(light.model_num, 0xA2)
-        self.assertEqual(light.model, "RGB Symphony [Addressable] (0xA2)")
+        self.assertEqual(light.model, "RGB Symphony 2 (0xA2)")
         assert len(light.effect_list) == 103
         assert light.color_modes == {COLOR_MODE_RGB}
 
@@ -1052,7 +1052,7 @@ class TestLight(unittest.TestCase):
         light = flux_led.WifiLedBulb("192.168.1.164")
         self.assertEqual(light.original_addressable, True)
         self.assertEqual(light.model_num, 0xA1)
-        self.assertEqual(light.model, "RGB Symphony [Addressable] (0xA1)")
+        self.assertEqual(light.model, "RGB Symphony Original (0xA1)")
         assert len(light.effect_list) == 300
         assert light.color_modes == {COLOR_MODE_RGB}
 


### PR DESCRIPTION
```python3
[{'firmware_date': datetime.date(2018, 10, 31),
  'id': '2462AB6F9133',
  'ipaddr': '192.168.209.213',
  'model': 'AK001-ZJ210',
  'model_description': 'RGB Symphony Original',
  'model_num': 161,
  'version_num': 24},
 {'firmware_date': datetime.date(2021, 1, 15),
  'id': '18B905C93F61',
  'ipaddr': '192.168.210.65',
  'model': 'AK001-ZJ2145',
  'model_description': 'RGBW Controller',
  'model_info': 'ZG-BL-IR',
  'model_num': 6,
  'version_num': 9},
 {'firmware_date': datetime.date(2021, 2, 4),
  'id': 'B4E842E10588',
  'ipaddr': '192.168.214.252',
  'model': 'AK001-ZJ2145',
  'model_description': 'RGB Controller with MIC',
  'model_info': 'ZG-BL',
  'model_num': 8,
  'version_num': 21},
 {'firmware_date': datetime.date(2021, 5, 20),
  'id': '7CB94C95A661',
  'ipaddr': '192.168.211.220',
  'model': 'AK001-ZJ2148',
  'model_description': 'RGB Symphony 3',
  'model_info': 'ZG-BL-5V',
  'model_num': 163,
  'version_num': 39},
 {'firmware_date': datetime.date(2021, 1, 6),
  'id': 'B4E842279C2A',
  'ipaddr': '192.168.214.215',
  'model': 'AK001-ZJ2146',
  'model_description': 'RGBCW Controller',
  'model_info': 'ZG-BL',
  'model_num': 7,
  'version_num': 6}]
```