### PR TITLE
Refactor color_temp_to_white_levels and improve code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,22 @@
+[run]
+source = flux_led
+
+omit =
+    flux_led/fluxled.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # TYPE_CHECKING and @overload blocks are never executed during pytest run
+    if TYPE_CHECKING:
+    @overload

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -181,13 +181,15 @@ class AIOWifiLedBulb(LEDENETDevice):
         self, effect: int, speed: int, brightness: int = 100
     ) -> None:
         """Set a preset pattern on the device."""
-        msg = self._generate_preset_pattern(effect, speed, brightness)
-        await self._async_send_msg(msg)
+        await self._async_send_msg(
+            self._generate_preset_pattern(effect, speed, brightness)
+        )
 
     async def async_set_custom_pattern(self, rgb_list, speed, transition_type):
         """Set a custom pattern on the device."""
-        msg = self._generate_custom_patterm(rgb_list, speed, transition_type)
-        await self._async_send_msg(msg)
+        await self._async_send_msg(
+            self._generate_custom_patterm(rgb_list, speed, transition_type)
+        )
 
     async def async_set_effect(
         self, effect: str, speed: int, brightness: int = 100

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -247,7 +247,6 @@ class AIOWifiLedBulb(LEDENETDevice):
 
     def _async_data_recieved(self, data):
         """New data on the socket."""
-        self.set_available()
         start_empty_buffer = not self._buffer
         self._buffer += data
         self._updates_without_response = 0
@@ -276,6 +275,7 @@ class AIOWifiLedBulb(LEDENETDevice):
             return
         if not self._protocol:
             return
+        self.set_available()
         assert self._updated_callback is not None
         prev_state = self.raw_state
         if self._protocol.is_valid_addressable_response(msg):

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -137,6 +137,7 @@ class AIOWifiLedBulb(LEDENETDevice):
         if self._updates_without_response == MAX_UPDATES_WITHOUT_RESPONSE:
             if self._aio_protocol:
                 self._aio_protocol.close()
+            self.set_unavailable()
             self._updates_without_response = 0
             raise RuntimeError("Bulb stopped responding")
         await self._async_send_state_query()
@@ -242,9 +243,11 @@ class AIOWifiLedBulb(LEDENETDevice):
     def _async_connection_lost(self, exc):
         """Called when the connection is lost."""
         self._aio_protocol = None
+        self.set_unavailable()
 
     def _async_data_recieved(self, data):
         """New data on the socket."""
+        self.set_available()
         start_empty_buffer = not self._buffer
         self._buffer += data
         self._updates_without_response = 0

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -273,8 +273,6 @@ class AIOWifiLedBulb(LEDENETDevice):
         if self._data_future and not self._data_future.done():
             self._data_future.set_result(msg)
             return
-        if not self._protocol:
-            return
         self.set_available()
         assert self._updated_callback is not None
         prev_state = self.raw_state

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -126,7 +126,7 @@ class AIOWifiLedBulb(LEDENETDevice):
 
     async def async_set_white_temp(self, temperature, brightness, persist=True) -> None:
         """Set the white tempature."""
-        cold, warm = color_temp_to_white_levels(temperature, brightness)
+        warm, cold = color_temp_to_white_levels(temperature, brightness)
         await self.async_set_levels(w=warm, w2=cold, persist=persist)
 
     async def async_update(self):

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -715,7 +715,6 @@ class LEDENETDevice:
         w2 = mapped_channels[STATE_COOL_WHITE]
 
         if (r or g or b) and (w or w2) and not self.rgbwcapable:
-            print("RGBW command sent to non-RGBW device")
             raise ValueError("RGBW command sent to non-RGBW device")
 
         if brightness is not None and r is not None and g is not None and b is not None:

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -824,9 +824,9 @@ class LEDENETDevice:
 
     def setProtocol(self, protocol: str) -> None:
         cls = PROTOCOL_NAME_TO_CLS.get(protocol)
-        if not cls:
+        if cls is None:
             raise ValueError(f"Invalid protocol: {protocol}")
-        self._protocol = cls()
+        self._protocol = cls()  # type: ignore
 
     def _set_protocol_from_msg(
         self,

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -113,6 +113,16 @@ SPEED_ADJUST_WILL_TURN_ON = {
     PROTOCOL_LEDENET_ADDRESSABLE_A1,
     PROTOCOL_LEDENET_ADDRESSABLE_A2,
 }
+PROTOCOL_NAME_TO_CLS = {
+    PROTOCOL_LEDENET_ORIGINAL: ProtocolLEDENETOriginal,
+    PROTOCOL_LEDENET_8BYTE: ProtocolLEDENET8Byte,
+    PROTOCOL_LEDENET_8BYTE_DIMMABLE_EFFECTS: ProtocolLEDENET8ByteDimmableEffects,
+    PROTOCOL_LEDENET_9BYTE: ProtocolLEDENET9Byte,
+    PROTOCOL_LEDENET_9BYTE_DIMMABLE_EFFECTS: ProtocolLEDENET9ByteDimmableEffects,
+    PROTOCOL_LEDENET_ADDRESSABLE_A3: ProtocolLEDENETAddressableA3,
+    PROTOCOL_LEDENET_ADDRESSABLE_A2: ProtocolLEDENETAddressableA2,
+    PROTOCOL_LEDENET_ADDRESSABLE_A1: ProtocolLEDENETAddressableA1,
+}
 
 
 class DeviceType(Enum):
@@ -813,24 +823,10 @@ class LEDENETDevice:
         return int(r), int(g), int(b)
 
     def setProtocol(self, protocol: str) -> None:
-        if protocol == PROTOCOL_LEDENET_ORIGINAL:
-            self._protocol = ProtocolLEDENETOriginal()
-        elif protocol == PROTOCOL_LEDENET_8BYTE:
-            self._protocol = ProtocolLEDENET8Byte()
-        elif protocol == PROTOCOL_LEDENET_8BYTE_DIMMABLE_EFFECTS:
-            self._protocol = ProtocolLEDENET8ByteDimmableEffects()
-        elif protocol == PROTOCOL_LEDENET_9BYTE:
-            self._protocol = ProtocolLEDENET9Byte()
-        elif protocol == PROTOCOL_LEDENET_9BYTE_DIMMABLE_EFFECTS:
-            self._protocol = ProtocolLEDENET9ByteDimmableEffects()
-        elif protocol == PROTOCOL_LEDENET_ADDRESSABLE_A3:
-            self._protocol = ProtocolLEDENETAddressableA3()
-        elif protocol == PROTOCOL_LEDENET_ADDRESSABLE_A2:
-            self._protocol = ProtocolLEDENETAddressableA2()
-        elif protocol == PROTOCOL_LEDENET_ADDRESSABLE_A1:
-            self._protocol = ProtocolLEDENETAddressableA1()
-        else:
+        cls = PROTOCOL_NAME_TO_CLS.get(protocol)
+        if not cls:
             raise ValueError(f"Invalid protocol: {protocol}")
+        self._protocol = cls()
 
     def _set_protocol_from_msg(
         self,

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -715,7 +715,7 @@ class LEDENETDevice:
         w2 = mapped_channels[STATE_COOL_WHITE]
 
         if (r or g or b) and (w or w2) and not self.rgbwcapable:
-            raise ValueError("RGBW command sent to non-RGBW device")
+            raise ValueError("RGB&CW command sent to non-RGB&CW device")
 
         if brightness is not None and r is not None and g is not None and b is not None:
             (r, g, b) = self._calculateBrightness((r, g, b), brightness)

--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -108,7 +108,7 @@ class WifiLedBulb(LEDENETDevice):
     def setWhiteTemperature(
         self, temperature, brightness, persist=True, retry=DEFAULT_RETRIES
     ):
-        cold, warm = color_temp_to_white_levels(temperature, brightness)
+        warm, cold = color_temp_to_white_levels(temperature, brightness)
         self.set_levels(w=warm, w2=cold, persist=persist, retry=retry)
 
     def setRgb(self, r, g, b, persist=True, brightness=None, retry=DEFAULT_RETRIES):

--- a/flux_led/utils.py
+++ b/flux_led/utils.py
@@ -2,7 +2,7 @@ import ast
 import colorsys
 import contextlib
 import datetime
-from typing import Iterable, List, Optional, Tuple, cast
+from typing import Iterable, List, Optional, Tuple, cast, Union
 
 import webcolors  # type: ignore
 
@@ -11,14 +11,16 @@ from .const import MAX_TEMP, MIN_TEMP
 
 class utils:
     @staticmethod
-    def color_object_to_tuple(color) -> Optional[Tuple[int, ...]]:
+    def color_object_to_tuple(
+        color: Union[Tuple[int, ...], str]
+    ) -> Optional[Tuple[int, ...]]:
 
         # see if it's already a color tuple
-        if type(color) is tuple and len(color) in [3, 4, 5]:
+        if isinstance(color, tuple) and len(color) in [3, 4, 5]:
             return color
 
         # can't convert non-string
-        if type(color) is not str:
+        if not isinstance(color, str):
             return None
         color = color.strip()
 

--- a/flux_led/utils.py
+++ b/flux_led/utils.py
@@ -88,10 +88,7 @@ class utils:
         # speed is 0-100, delay is 1-31
         # 1st translate delay to 0-30
         delay = delay - 1
-        if delay > utils.max_delay - 1:
-            delay = utils.max_delay - 1
-        if delay < 0:
-            delay = 0
+        delay = max(0, min(utils.max_delay - 1, delay))
         inv_speed = int((delay * 100) / (utils.max_delay - 1))
         speed = 100 - inv_speed
         return speed
@@ -99,10 +96,7 @@ class utils:
     @staticmethod
     def speedToDelay(speed: int) -> int:
         # speed is 0-100, delay is 1-31
-        if speed > 100:
-            speed = 100
-        if speed < 0:
-            speed = 0
+        speed = max(0, min(100, speed))
         inv_speed = 100 - speed
         delay = int((inv_speed * (utils.max_delay - 1)) / 100)
         # translate from 0-30 to 1-31
@@ -111,19 +105,11 @@ class utils:
 
     @staticmethod
     def byteToPercent(byte: int) -> int:
-        if byte > 255:
-            byte = 255
-        if byte < 0:
-            byte = 0
-        return int((byte * 100) / 255)
+        return int((max(0, min(255, byte)) * 100) / 255)
 
     @staticmethod
     def percentToByte(percent: int) -> int:
-        if percent > 100:
-            percent = 100
-        if percent < 0:
-            percent = 0
-        return int((percent * 255) / 100)
+        return int((max(0, min(100, percent)) * 255) / 100)
 
 
 def rgbwc_to_rgbcw(

--- a/flux_led/utils.py
+++ b/flux_led/utils.py
@@ -45,13 +45,10 @@ class utils:
         return None
 
     @staticmethod
-    def color_tuple_to_string(rgb) -> str:
+    def color_tuple_to_string(rgb: Tuple[int, int, int]) -> str:
         # try to convert to an english name
-        try:
+        with contextlib.suppress(Exception):
             return webcolors.rgb_to_name(rgb)
-        except Exception:
-            # print e
-            pass
         return str(rgb)
 
     @staticmethod

--- a/flux_led/utils.py
+++ b/flux_led/utils.py
@@ -66,8 +66,7 @@ class utils:
 
     @staticmethod
     def date_has_passed(dt) -> bool:
-        delta = dt - datetime.datetime.now()
-        return delta.total_seconds() < 0
+        return (dt - datetime.datetime.now()).total_seconds() < 0
 
     @staticmethod
     def dump_bytes(bytes) -> None:

--- a/flux_led/utils.py
+++ b/flux_led/utils.py
@@ -56,16 +56,16 @@ class utils:
 
     @staticmethod
     def get_color_names_list() -> List[str]:
-        names = set()
-        for key in list(webcolors.CSS2_HEX_TO_NAMES.keys()):
-            names.add(webcolors.CSS2_HEX_TO_NAMES[key])
-        for key in list(webcolors.CSS21_HEX_TO_NAMES.keys()):
-            names.add(webcolors.CSS21_HEX_TO_NAMES[key])
-        for key in list(webcolors.CSS3_HEX_TO_NAMES.keys()):
-            names.add(webcolors.CSS3_HEX_TO_NAMES[key])
-        for key in list(webcolors.HTML4_HEX_TO_NAMES.keys()):
-            names.add(webcolors.HTML4_HEX_TO_NAMES[key])
-        return sorted(names)
+        return sorted(
+            set(
+                [
+                    *webcolors.CSS2_HEX_TO_NAMES.values(),
+                    *webcolors.CSS21_HEX_TO_NAMES.values(),
+                    *webcolors.CSS3_HEX_TO_NAMES.values(),
+                    *webcolors.HTML4_HEX_TO_NAMES.values(),
+                ]
+            )
+        )
 
     @staticmethod
     def date_has_passed(dt) -> bool:

--- a/flux_led/utils.py
+++ b/flux_led/utils.py
@@ -69,10 +69,6 @@ class utils:
         return (dt - datetime.datetime.now()).total_seconds() < 0
 
     @staticmethod
-    def dump_bytes(bytes) -> None:
-        print("".join(f"{x:02x} " for x in bytearray(bytes)))
-
-    @staticmethod
     def raw_state_to_dec(rx: Iterable[int]) -> str:
         raw_state_str = ""
         for _r in rx:

--- a/tests.py
+++ b/tests.py
@@ -31,6 +31,7 @@ from flux_led.utils import (
     rgbcw_brightness,
     rgbwc_to_rgbcw,
     rgbcw_to_rgbwc,
+    utils,
 )
 
 LEDENET_STATE_QUERY = b"\x81\x8a\x8b\x96"
@@ -949,6 +950,15 @@ class TestLight(unittest.TestCase):
         rgbcw = rgbwc_to_rgbcw(rgbwc)
         assert rgbcw == (1, 2, 3, 5, 4)
         assert rgbcw_to_rgbwc(rgbcw) == rgbwc
+
+    def test_color_object_to_tuple(self):
+        assert utils.color_object_to_tuple("red") == (255, 0, 0)
+        assert utils.color_object_to_tuple("green") == (0, 128, 0)
+        assert utils.color_object_to_tuple("blue") == (0, 0, 255)
+        green = (0, 255, 0)
+        assert utils.color_object_to_tuple(green) == green
+        assert utils.color_object_to_tuple("#ff00ff") == (255, 0, 255)
+        assert utils.color_object_to_tuple("(255,0,255)") == (255, 0, 255)
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")

--- a/tests.py
+++ b/tests.py
@@ -985,6 +985,10 @@ class TestLight(unittest.TestCase):
         assert color_temp_to_white_levels(5000, 128) == (50, 77)
         assert color_temp_to_white_levels(6500, 128) == (0, 128)
         assert color_temp_to_white_levels(6500, 255) == (0, 255)
+        with pytest.raises(ValueError):
+            color_temp_to_white_levels(6500, -1)
+        with pytest.raises(ValueError):
+            color_temp_to_white_levels(-1, 255)
 
     def test_white_levels_to_color_temp(self):
         assert white_levels_to_color_temp(0, 255) == (6500, 255)
@@ -995,6 +999,10 @@ class TestLight(unittest.TestCase):
         assert white_levels_to_color_temp(64, 64) == (4600, 128)
         assert white_levels_to_color_temp(77, 50) == (4196, 127)
         assert white_levels_to_color_temp(128, 0) == (2700, 128)
+        with pytest.raises(ValueError):
+            white_levels_to_color_temp(-1, 0)
+        with pytest.raises(ValueError):
+            white_levels_to_color_temp(0, 500)
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")

--- a/tests.py
+++ b/tests.py
@@ -31,6 +31,8 @@ from flux_led.utils import (
     rgbcw_brightness,
     rgbwc_to_rgbcw,
     rgbcw_to_rgbwc,
+    white_levels_to_color_temp,
+    color_temp_to_white_levels,
     utils,
 )
 
@@ -972,6 +974,27 @@ class TestLight(unittest.TestCase):
         assert utils.color_tuple_to_string((0, 128, 0)) == "green"
         assert utils.color_tuple_to_string((0, 0, 255)) == "blue"
         assert utils.color_tuple_to_string((3, 2, 1)) == "(3, 2, 1)"
+
+    def test_color_temp_to_white_levels(self):
+        assert color_temp_to_white_levels(2700, 255) == (255, 0)
+        assert color_temp_to_white_levels(4600, 255) == (128, 128)
+        assert color_temp_to_white_levels(5000, 255) == (101, 154)
+        assert color_temp_to_white_levels(6500, 255) == (0, 255)
+        assert color_temp_to_white_levels(2700, 128) == (128, 0)
+        assert color_temp_to_white_levels(4600, 128) == (64, 64)
+        assert color_temp_to_white_levels(5000, 128) == (50, 77)
+        assert color_temp_to_white_levels(6500, 128) == (0, 128)
+        assert color_temp_to_white_levels(6500, 255) == (0, 255)
+
+    def test_white_levels_to_color_temp(self):
+        assert white_levels_to_color_temp(0, 255) == (6500, 255)
+        assert white_levels_to_color_temp(255, 255) == (4600, 255)
+        assert white_levels_to_color_temp(128, 128) == (4600, 255)
+        assert white_levels_to_color_temp(255, 0) == (2700, 255)
+        assert white_levels_to_color_temp(0, 128) == (6500, 128)
+        assert white_levels_to_color_temp(64, 64) == (4600, 128)
+        assert white_levels_to_color_temp(77, 50) == (4196, 127)
+        assert white_levels_to_color_temp(128, 0) == (2700, 128)
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")

--- a/tests.py
+++ b/tests.py
@@ -966,6 +966,12 @@ class TestLight(unittest.TestCase):
         assert "springgreen" in names
         assert "yellow" in names
 
+    def test_color_tuple_to_string(self):
+        assert utils.color_tuple_to_string((255, 0, 0)) == "red"
+        assert utils.color_tuple_to_string((0, 128, 0)) == "green"
+        assert utils.color_tuple_to_string((0, 0, 255)) == "blue"
+        assert utils.color_tuple_to_string((3, 2, 1)) == "(3, 2, 1)"
+
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")
     @patch("flux_led.WifiLedBulb.connect")

--- a/tests.py
+++ b/tests.py
@@ -1170,7 +1170,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(mock_send.call_count, 3)
         self.assertEqual(
             mock_send.call_args,
-            mock.call(bytearray(b'B\x012d\xd9')),
+            mock.call(bytearray(b"B\x012d\xd9")),
         )
         light._transition_complete_time = 0
         light.update_state()
@@ -1179,7 +1179,7 @@ class TestLight(unittest.TestCase):
             "ON  [Pattern: RBM 1 (Speed 16%) raw state: 129,162,35,37,1,16,100,0,0,0,4,0,240,212,]",
         )
         assert light.effect == "RBM 1"
-        assert light.brightness == 55
+        assert light.brightness == 255
         assert light.getSpeed() == 16
 
     @patch("flux_led.WifiLedBulb._send_msg")
@@ -1257,7 +1257,7 @@ class TestLight(unittest.TestCase):
             "ON  [Pattern: RBM 1 (Speed 16%) raw state: 129,163,35,37,1,16,100,0,0,0,4,0,240,213,]",
         )
         assert light.effect == "RBM 1"
-        assert light.brightness == 55
+        assert light.brightness == 255
         assert light.getSpeed() == 16
 
     @patch("flux_led.WifiLedBulb._send_msg")
@@ -1322,6 +1322,8 @@ class TestLight(unittest.TestCase):
         self.assertEqual(mock_read.call_count, 2)
         self.assertEqual(mock_send.call_count, 3)
         self.assertEqual(mock_send.call_args, mock.call(bytearray(b"a\x00\xa12\x0fC")))
+        assert light.brightness == 255
+
         light._transition_complete_time = 0
         light.update_state()
         self.assertEqual(
@@ -1334,5 +1336,4 @@ class TestLight(unittest.TestCase):
         )
         assert light.getSpeed() == 1
         light.set_effect("random", 50)
-        assert light.brightness == 55
         self.assertEqual(mock_send.call_count, 5)

--- a/tests.py
+++ b/tests.py
@@ -354,6 +354,8 @@ class TestLight(unittest.TestCase):
             "OFF  [Color: (255, 91, 212) Brightness: 100% raw state: 129,69,36,97,33,16,255,91,212,0,4,0,240,158,]",
         )
         self.assertEqual(light.protocol, PROTOCOL_LEDENET_8BYTE)
+        self.assertEqual(light.getWarmWhite255(), 255)
+        self.assertEqual(light.getCCT(), (255, 255))
         self.assertEqual(light.is_on, False)
         self.assertEqual(light.mode, "color")
         self.assertEqual(light.warm_white, 0)
@@ -1011,8 +1013,8 @@ class TestLight(unittest.TestCase):
                 return bytearray(b"$$\x44\x00\x00\x00\x00\x00\x02\x00\x00\xed")
 
         mock_read.side_effect = read_data
-        switch = flux_led.WifiLedBulb("192.168.1.164")
-        assert switch.color_modes == {COLOR_MODE_RGBW}
+        light = flux_led.WifiLedBulb("192.168.1.164")
+        assert light.color_modes == {COLOR_MODE_RGBW}
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")

--- a/tests.py
+++ b/tests.py
@@ -742,6 +742,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.model_num, 0x01)
         self.assertEqual(light.model, "Original LEDENET (0x01)")
         self.assertEqual(light.dimmable_effects, False)
+        self.assertEqual(light.white_active, True)
 
         self.assertEqual(mock_read.call_count, 3)
         self.assertEqual(mock_send.call_count, 2)

--- a/tests.py
+++ b/tests.py
@@ -957,6 +957,7 @@ class TestLight(unittest.TestCase):
         assert utils.color_object_to_tuple("blue") == (0, 0, 255)
         green = (0, 255, 0)
         assert utils.color_object_to_tuple(green) == green
+        assert utils.color_object_to_tuple(set()) is None
         assert utils.color_object_to_tuple("#ff00ff") == (255, 0, 255)
         assert utils.color_object_to_tuple("(255,0,255)") == (255, 0, 255)
 

--- a/tests.py
+++ b/tests.py
@@ -1134,6 +1134,7 @@ class TestLight(unittest.TestCase):
 
         mock_read.side_effect = read_data
         light = flux_led.WifiLedBulb("192.168.1.164")
+        self.assertEqual(light.speed_adjust_off, False)
         self.assertEqual(light.model_num, 0xA2)
         self.assertEqual(light.microphone, True)
         self.assertEqual(light.model, "RGB Symphony v2 (0xA2)")
@@ -1206,6 +1207,7 @@ class TestLight(unittest.TestCase):
 
         mock_read.side_effect = read_data
         light = flux_led.WifiLedBulb("192.168.1.164")
+        self.assertEqual(light.speed_adjust_off, True)
         self.assertEqual(light.model_num, 0xA3)
         self.assertEqual(light.microphone, True)
         self.assertEqual(light.model, "RGB Symphony v3 (0xA3)")
@@ -1286,8 +1288,10 @@ class TestLight(unittest.TestCase):
 
         mock_read.side_effect = read_data
         light = flux_led.WifiLedBulb("192.168.1.164")
+        self.assertEqual(light.speed_adjust_off, False)
         self.assertEqual(light.dimmable_effects, False)
         self.assertEqual(light.model_num, 0xA1)
+
         self.assertEqual(light.model, "RGB Symphony v1 (0xA1)")
         assert len(light.effect_list) == 301
         assert light.color_modes == {COLOR_MODE_RGB}

--- a/tests.py
+++ b/tests.py
@@ -960,6 +960,12 @@ class TestLight(unittest.TestCase):
         assert utils.color_object_to_tuple("#ff00ff") == (255, 0, 255)
         assert utils.color_object_to_tuple("(255,0,255)") == (255, 0, 255)
 
+    def test_get_color_names_list(self):
+        names = utils.get_color_names_list()
+        assert len(names) > 120
+        assert "springgreen" in names
+        assert "yellow" in names
+
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")
     @patch("flux_led.WifiLedBulb.connect")

--- a/tests.py
+++ b/tests.py
@@ -999,6 +999,7 @@ class TestLight(unittest.TestCase):
         assert white_levels_to_color_temp(64, 64) == (4600, 128)
         assert white_levels_to_color_temp(77, 50) == (4196, 127)
         assert white_levels_to_color_temp(128, 0) == (2700, 128)
+        assert white_levels_to_color_temp(0, 0) == (2700, 0)
         with pytest.raises(ValueError):
             white_levels_to_color_temp(-1, 0)
         with pytest.raises(ValueError):

--- a/tests.py
+++ b/tests.py
@@ -25,7 +25,13 @@ from flux_led.protocol import (
     PROTOCOL_LEDENET_ADDRESSABLE_A3,
     PROTOCOL_LEDENET_ORIGINAL,
 )
-from flux_led.utils import rgbw_brightness, rgbww_brightness
+from flux_led.utils import (
+    rgbw_brightness,
+    rgbww_brightness,
+    rgbcw_brightness,
+    rgbwc_to_rgbcw,
+    rgbcw_to_rgbwc,
+)
 
 LEDENET_STATE_QUERY = b"\x81\x8a\x8b\x96"
 
@@ -906,12 +912,43 @@ class TestLight(unittest.TestCase):
         assert rgbww_brightness((0, 255, 0, 0, 0), 255) == (0, 255, 0, 255, 255)
         assert rgbww_brightness((0, 255, 0, 0, 0), 128) == (0, 255, 0, 64, 64)
 
+    def test_rgbcw_brightness(self):
+        assert rgbcw_brightness((128, 128, 128, 128, 128), 255) == (
+            255,
+            255,
+            255,
+            255,
+            255,
+        )
+        assert rgbcw_brightness((128, 128, 128, 128, 128), 128) == (
+            128,
+            128,
+            128,
+            128,
+            128,
+        )
+        assert rgbcw_brightness((255, 255, 255, 255, 255), 128) == (
+            128,
+            128,
+            128,
+            128,
+            128,
+        )
+        assert rgbcw_brightness((0, 255, 0, 0, 0), 255) == (0, 255, 0, 255, 255)
+        assert rgbcw_brightness((0, 255, 0, 0, 0), 128) == (0, 255, 0, 64, 64)
+
     def test_rgbw_brightness(self):
         assert rgbw_brightness((128, 128, 128, 128), 255) == (255, 255, 255, 255)
         assert rgbw_brightness((128, 128, 128, 128), 128) == (128, 128, 128, 128)
         assert rgbw_brightness((255, 255, 255, 255), 128) == (128, 128, 128, 128)
         assert rgbw_brightness((0, 255, 0, 0), 255) == (0, 255, 0, 255)
         assert rgbw_brightness((0, 255, 0, 0), 128) == (0, 255, 0, 0)
+
+    def test_rgbwc_to_rgbcw_rgbcw_to_rgbwc_round_trip(self):
+        rgbwc = (1, 2, 3, 4, 5)
+        rgbcw = rgbwc_to_rgbcw(rgbwc)
+        assert rgbcw == (1, 2, 3, 5, 4)
+        assert rgbcw_to_rgbwc(rgbcw) == rgbwc
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")

--- a/tests.py
+++ b/tests.py
@@ -1179,6 +1179,7 @@ class TestLight(unittest.TestCase):
             "ON  [Pattern: RBM 1 (Speed 16%) raw state: 129,162,35,37,1,16,100,0,0,0,4,0,240,212,]",
         )
         assert light.effect == "RBM 1"
+        assert light.brightness == 55
         assert light.getSpeed() == 16
 
     @patch("flux_led.WifiLedBulb._send_msg")
@@ -1256,6 +1257,7 @@ class TestLight(unittest.TestCase):
             "ON  [Pattern: RBM 1 (Speed 16%) raw state: 129,163,35,37,1,16,100,0,0,0,4,0,240,213,]",
         )
         assert light.effect == "RBM 1"
+        assert light.brightness == 55
         assert light.getSpeed() == 16
 
     @patch("flux_led.WifiLedBulb._send_msg")
@@ -1332,4 +1334,5 @@ class TestLight(unittest.TestCase):
         )
         assert light.getSpeed() == 1
         light.set_effect("random", 50)
+        assert light.brightness == 55
         self.assertEqual(mock_send.call_count, 5)

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -359,7 +359,7 @@ async def test_async_set_brightness_cct(mock_aio_protocol):
     task = asyncio.create_task(light.async_setup(_updated_callback))
     transport, protocol = await mock_aio_protocol()
     light._aio_protocol.data_received(
-        b"\x81\x25\x23\x61\x05\x10\xb6\x00\x98\x19\x04\x25\x0f\xde"
+        b"\x81\x25\x23\x61\x02\x10\xb6\x00\x98\x19\x04\x25\x0f\xdb"
     )
     await task
 
@@ -369,12 +369,14 @@ async def test_async_set_brightness_cct(mock_aio_protocol):
     transport.reset_mock()
     await light.async_set_brightness(255)
     assert transport.mock_calls[0][0] == "write"
-    assert transport.mock_calls[0][1][0] == b"1\xff\x00\xd5\xff\xff\x00\x0f\x12"
+    assert transport.mock_calls[0][1][0] == b"1\x00\x00\x00g\x98\x0f\x0fN"
+    assert light.brightness == 255
 
     transport.reset_mock()
     await light.async_set_brightness(128)
     assert transport.mock_calls[0][0] == "write"
-    assert transport.mock_calls[0][1][0] == b"1\x80\x00k\x80\x80\x00\x0f+"
+    assert transport.mock_calls[0][1][0] == b"1\x00\x00\x004L\x0f\x0f\xcf"
+    assert light.brightness == 128
 
 
 @pytest.mark.asyncio

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -425,11 +425,38 @@ async def test_async_set_custom_effect(
     assert light.model_num == 0x25
 
     transport.reset_mock()
-    await light.async_set_custom_pattern([(255, 0, 255), (255, 0, 0)], 50, "jump")
+
+    # no values
+    with pytest.raises(ValueError):
+        await light.async_set_custom_pattern([], 50, "jump")
+
+    await light.async_set_custom_pattern(
+        [
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 0),
+            (255, 0, 255),
+            (255, 0, 0),
+            (255, 0, 0),
+        ],
+        50,
+        "jump",
+    )
     assert transport.mock_calls[0][0] == "write"
     assert (
         transport.mock_calls[0][1][0]
-        == b"Q\xff\x00\xff\x00\xff\x00\x00\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x01\x02\x03\x00\x10;\xff\x0f\xfb"
+        == b"Q\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\xff\x00\xff\x00\x00\x00\x10;\xff\x0f\x99"
     )
 
 

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -359,6 +359,34 @@ async def test_handling_unavailable_after_no_response(mock_aio_protocol):
 
 
 @pytest.mark.asyncio
+async def test_async_set_levels(mock_aio_protocol, caplog: pytest.LogCaptureFixture):
+    """Test we can set levels."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, protocol = await mock_aio_protocol()
+    light._aio_protocol.data_received(
+        b"\x81\x33#\x25\x01\x10\x64\x00\x00\x00\x04\x00\xf0\x65"
+    )
+    await task
+    assert light.model_num == 0x33
+    assert light.dimmable_effects is False
+
+    transport.reset_mock()
+    with pytest.raises(ValueError):
+        # ValueError: RGBW command sent to non-RGBW devic
+        await light.async_set_levels(255, 255, 255, 255, 255)
+
+    await light.async_set_levels(255, 0, 0)
+
+    assert transport.mock_calls[0][0] == "write"
+    assert transport.mock_calls[0][1][0] == b"1\xff\x00\x00\x00\x00\x0f?"
+
+
+@pytest.mark.asyncio
 async def test_async_set_effect(mock_aio_protocol, caplog: pytest.LogCaptureFixture):
     """Test we can set an effect."""
     light = AIOWifiLedBulb("192.168.1.166")

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -11,7 +11,7 @@ from flux_led.aio import AIOWifiLedBulb
 from flux_led.aioprotocol import AIOLEDENETProtocol
 from flux_led.aioscanner import AIOBulbScanner, LEDENETDiscovery
 from flux_led.const import COLOR_MODE_CCT, COLOR_MODE_RGBWW
-from flux_led.protocol import PROTOCOL_LEDENET_9BYTE
+from flux_led.protocol import PROTOCOL_LEDENET_9BYTE, PROTOCOL_LEDENET_ORIGINAL
 
 
 @pytest.fixture
@@ -66,6 +66,7 @@ async def mock_aio_protocol():
 async def test_no_initial_response(mock_aio_protocol):
     """Test we try switching protocol if we get no initial response."""
     light = AIOWifiLedBulb("192.168.1.166", timeout=0.1)
+    assert light.protocol is None
 
     def _updated_callback(*args, **kwargs):
         pass
@@ -82,6 +83,7 @@ async def test_no_initial_response(mock_aio_protocol):
         call.close(),
     ]
     assert not light.available
+    assert light.protocol is PROTOCOL_LEDENET_ORIGINAL
 
 
 @pytest.mark.asyncio

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -380,6 +380,99 @@ async def test_async_set_brightness_cct(mock_aio_protocol):
 
 
 @pytest.mark.asyncio
+async def test_async_set_brightness_dim(mock_aio_protocol):
+    """Test we can set brightness with a dim only device."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, protocol = await mock_aio_protocol()
+    light._aio_protocol.data_received(
+        b"\x81\x25\x23\x61\x01\x10\xb6\x00\x98\x19\x04\x25\x0f\xda"
+    )
+    await task
+
+    await light.async_stop()
+    await asyncio.sleep(0)  # make sure nothing throws
+
+    transport.reset_mock()
+    await light.async_set_brightness(255)
+    assert transport.mock_calls[0][0] == "write"
+    assert transport.mock_calls[0][1][0] == b"1\x00\x00\x00\xff\xff\x0f\x0fM"
+    assert light.brightness == 255
+
+    transport.reset_mock()
+    await light.async_set_brightness(128)
+    assert transport.mock_calls[0][0] == "write"
+    assert transport.mock_calls[0][1][0] == b"1\x00\x00\x00\x80\x80\x0f\x0fO"
+    assert light.brightness == 128
+
+
+@pytest.mark.asyncio
+async def test_async_set_brightness_rgb(mock_aio_protocol):
+    """Test we can set brightness with a rgb only device."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, protocol = await mock_aio_protocol()
+    light._aio_protocol.data_received(
+        b"\x81\x25\x23\x61\x03\x10\xb6\x00\x98\x19\x04\x25\x0f\xdc"
+    )
+    await task
+
+    await light.async_stop()
+    await asyncio.sleep(0)  # make sure nothing throws
+
+    transport.reset_mock()
+    await light.async_set_brightness(255)
+    assert transport.mock_calls[0][0] == "write"
+    assert transport.mock_calls[0][1][0] == b"1\xff\x00\xd4\x00\x00\xf0\x0f\x03"
+    assert light.brightness == 255
+
+    transport.reset_mock()
+    await light.async_set_brightness(128)
+    assert transport.mock_calls[0][0] == "write"
+    assert transport.mock_calls[0][1][0] == b"1\x80\x00j\x00\x00\xf0\x0f\x1a"
+    assert light.brightness == 128
+
+
+@pytest.mark.asyncio
+async def test_async_set_brightness_rgbw(mock_aio_protocol):
+    """Test we can set brightness with a rgbw only device."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, protocol = await mock_aio_protocol()
+    light._aio_protocol.data_received(
+        b"\x81\x25\x23\x61\x04\x10\xb6\x00\x98\x19\x04\x25\x0f\xdd"
+    )
+    await task
+
+    await light.async_stop()
+    await asyncio.sleep(0)  # make sure nothing throws
+
+    transport.reset_mock()
+    await light.async_set_brightness(255)
+    assert transport.mock_calls[0][0] == "write"
+    assert transport.mock_calls[0][1][0] == b"1\xff\x00\xd5\xff\xff\x00\x0f\x12"
+    assert light.brightness == 255
+
+    transport.reset_mock()
+    await light.async_set_brightness(128)
+    assert transport.mock_calls[0][0] == "write"
+    assert transport.mock_calls[0][1][0] == b"1\x80\x00k\x80\x80\x00\x0f+"
+    assert light.brightness == 128
+
+
+@pytest.mark.asyncio
 async def test_async_scanner(mock_discovery_aio_protocol):
     """Test scanner."""
     scanner = AIOBulbScanner()

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import datetime
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 import pytest
 
@@ -60,6 +60,28 @@ async def mock_aio_protocol():
 
     with patch.object(loop, "create_connection", _mock_create_connection):
         yield _wait_for_connection
+
+
+@pytest.mark.asyncio
+async def test_no_initial_response(mock_aio_protocol):
+    """Test we try switching protocol if we get no initial response."""
+    light = AIOWifiLedBulb("192.168.1.166", timeout=0.1)
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, protocol = await mock_aio_protocol()
+    with pytest.raises(RuntimeError):
+        await task
+
+    assert transport.mock_calls == [
+        call.get_extra_info("peername"),
+        call.write(bytearray(b"\x81\x8a\x8b\x96")),
+        call.write_eof(),
+        call.close(),
+    ]
+    assert not light.available
 
 
 @pytest.mark.asyncio

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -349,6 +349,35 @@ async def test_async_set_brightness(mock_aio_protocol):
 
 
 @pytest.mark.asyncio
+async def test_async_set_brightness_cct(mock_aio_protocol):
+    """Test we can set brightness with a cct device."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, protocol = await mock_aio_protocol()
+    light._aio_protocol.data_received(
+        b"\x81\x25\x23\x61\x05\x10\xb6\x00\x98\x19\x04\x25\x0f\xde"
+    )
+    await task
+
+    await light.async_stop()
+    await asyncio.sleep(0)  # make sure nothing throws
+
+    transport.reset_mock()
+    await light.async_set_brightness(255)
+    assert transport.mock_calls[0][0] == "write"
+    assert transport.mock_calls[0][1][0] == b"1\xff\x00\xd5\xff\xff\x00\x0f\x12"
+
+    transport.reset_mock()
+    await light.async_set_brightness(128)
+    assert transport.mock_calls[0][0] == "write"
+    assert transport.mock_calls[0][1][0] == b"1\x80\x00k\x80\x80\x00\x0f+"
+
+
+@pytest.mark.asyncio
 async def test_async_scanner(mock_discovery_aio_protocol):
     """Test scanner."""
     scanner = AIOBulbScanner()

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -575,7 +575,7 @@ async def test_async_scanner_times_out_with_nothing(mock_discovery_aio_protocol)
     """Test scanner."""
     scanner = AIOBulbScanner()
 
-    task = asyncio.ensure_future(scanner.async_scan(timeout=0.0000001))
+    task = asyncio.ensure_future(scanner.async_scan(timeout=0.05))
     transport, protocol = await mock_discovery_aio_protocol()
     data = await task
     assert data == []
@@ -589,7 +589,7 @@ async def test_async_scanner_times_out_with_nothing_specific_address(
     scanner = AIOBulbScanner()
 
     task = asyncio.ensure_future(
-        scanner.async_scan(timeout=0.0000001, address="192.168.213.252")
+        scanner.async_scan(timeout=0.05, address="192.168.213.252")
     )
     transport, protocol = await mock_discovery_aio_protocol()
     data = await task


### PR DESCRIPTION
Technically breaking change:

`color_temp_to_white_levels` now returns `(warm_white, cold_white)` instead of `(cold_white, warm_white)` to be consistent with the rest of the library.

This function was only used internally so its unlikely to actually cause breakage.