### PR TITLE
Fix 0xA3 model brightness flip flop after change

### DIFF
--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -181,6 +181,7 @@ class AIOWifiLedBulb(LEDENETDevice):
         self, effect: int, speed: int, brightness: int = 100
     ) -> None:
         """Set a preset pattern on the device."""
+        self._set_transition_complete_time()
         await self._async_send_msg(
             self._generate_preset_pattern(effect, speed, brightness)
         )

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -386,7 +386,10 @@ class LEDENETDevice:
         assert raw_state is not None
 
         if self.dimmable_effects and self._mode == MODE_PRESET:
-            if self.protocol in NEW_EFFECTS_PROTOCOLS:
+            if (
+                self.protocol in NEW_EFFECTS_PROTOCOLS
+                and time.monotonic() > self._transition_complete_time
+            ):
                 # the red byte holds the brightness during an effect
                 return min(255, round(raw_state.red * 255 / 100))
             return round(self._last_effect_brightness * 255 / 100)

--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -270,6 +270,7 @@ class WifiLedBulb(LEDENETDevice):
         raise Exception("Cannot determine protocol")
 
     def setPresetPattern(self, pattern, speed, brightness=100, retry=DEFAULT_RETRIES):
+        self._set_transition_complete_time()
         self._send_with_retry(
             self._generate_preset_pattern(pattern, speed, brightness), retry=retry
         )


### PR DESCRIPTION
The brightness takes the transition time to update.  We were only accounting for this for r/g/b/c/w but not brightness.