### PR TITLE
Fix flood light devices sometimes missing turn on/off

### DIFF
--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -94,7 +94,12 @@ class AIOWifiLedBulb(LEDENETDevice):
 
     async def async_turn_on(self) -> bool:
         """Turn on the device."""
-        calls = (self._async_turn_on, self._async_turn_off_on, self._async_turn_on)
+        calls = (
+            self._async_turn_on,
+            self._async_turn_off_on,
+            self._async_turn_on,
+            self._async_turn_on,
+        )
         for idx, call in enumerate(calls):
             if (
                 await self._async_execute_and_wait_for(self._on_futures, call)
@@ -116,7 +121,12 @@ class AIOWifiLedBulb(LEDENETDevice):
 
     async def async_turn_off(self) -> bool:
         """Turn off the device."""
-        calls = (self._async_turn_off, self._async_turn_on_off, self._async_turn_off)
+        calls = (
+            self._async_turn_off,
+            self._async_turn_on_off,
+            self._async_turn_off,
+            self._async_turn_off,
+        )
         for idx, call in enumerate(calls):
             if (
                 await self._async_execute_and_wait_for(self._off_futures, call)

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -184,14 +184,15 @@ async def test_turn_on_off(mock_aio_protocol, caplog: pytest.LogCaptureFixture):
     caplog.clear()
     caplog.set_level(logging.DEBUG)
     # Handle the failure case
-    with patch.object(aiodevice, "POWER_STATE_TIMEOUT", 0.05):
+    with patch.object(aiodevice, "POWER_STATE_TIMEOUT", 0.025):
         await asyncio.create_task(light.async_turn_off())
         assert light.is_on is True
-        assert "Failed to turn off (1/3)" in caplog.text
-        assert "Failed to turn off (2/3)" in caplog.text
-        assert "Failed to turn off (3/3)" in caplog.text
+        assert "Failed to turn off (1/4)" in caplog.text
+        assert "Failed to turn off (2/4)" in caplog.text
+        assert "Failed to turn off (3/4)" in caplog.text
+        assert "Failed to turn off (4/4)" in caplog.text
 
-    with patch.object(aiodevice, "POWER_STATE_TIMEOUT", 0.05):
+    with patch.object(aiodevice, "POWER_STATE_TIMEOUT", 0.025):
         task = asyncio.create_task(light.async_turn_off())
         # Do NOT wait for the future to get added, we know the retry logic works
         light._aio_protocol.data_received(
@@ -205,12 +206,13 @@ async def test_turn_on_off(mock_aio_protocol, caplog: pytest.LogCaptureFixture):
     caplog.clear()
     caplog.set_level(logging.DEBUG)
     # Handle the failure case
-    with patch.object(aiodevice, "POWER_STATE_TIMEOUT", 0.05):
+    with patch.object(aiodevice, "POWER_STATE_TIMEOUT", 0.025):
         await asyncio.create_task(light.async_turn_on())
         assert light.is_on is False
-        assert "Failed to turn on (1/3)" in caplog.text
-        assert "Failed to turn on (2/3)" in caplog.text
-        assert "Failed to turn on (3/3)" in caplog.text
+        assert "Failed to turn on (1/4)" in caplog.text
+        assert "Failed to turn on (2/4)" in caplog.text
+        assert "Failed to turn on (3/4)" in caplog.text
+        assert "Failed to turn on (4/4)" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -817,7 +819,7 @@ async def test_async_scanner_times_out_with_nothing(mock_discovery_aio_protocol)
     """Test scanner."""
     scanner = AIOBulbScanner()
 
-    task = asyncio.ensure_future(scanner.async_scan(timeout=0.05))
+    task = asyncio.ensure_future(scanner.async_scan(timeout=0.025))
     transport, protocol = await mock_discovery_aio_protocol()
     data = await task
     assert data == []
@@ -831,7 +833,7 @@ async def test_async_scanner_times_out_with_nothing_specific_address(
     scanner = AIOBulbScanner()
 
     task = asyncio.ensure_future(
-        scanner.async_scan(timeout=0.05, address="192.168.213.252")
+        scanner.async_scan(timeout=0.025, address="192.168.213.252")
     )
     transport, protocol = await mock_discovery_aio_protocol()
     data = await task


### PR DESCRIPTION
- These devices sometimes take up to 4s to respond.  We currently only give 3.6s