### PR TITLE
Fix concurrent discovery

### DIFF
--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -112,10 +112,7 @@ class BulbScanner:
     def _create_socket(self) -> socket.socket:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        with contextlib.suppress(Exception):
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-        sock.bind(("", self.DISCOVERY_PORT))
+        sock.bind(("", 0))
         sock.setblocking(False)
         return sock
 

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 from datetime import date
 import logging
 import select


### PR DESCRIPTION
- Previously discovery would always listen on port 48899
  which is the outbound port. Since the devices will respond
  on to any port we now use an available ephemeral port to
  ensure multiple discoveries can run concurrently without
  mixing responses