### PR TITLE
Ensure multiple asyncio discoveries can combine data

### DIFF
--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import logging
 import time
-from typing import Callable, Dict, List, Optional, Tuple, cast
+from typing import Callable, List, Optional, Tuple, cast
 
 from .scanner import BulbScanner, FluxLEDDiscovery
 

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -77,11 +77,10 @@ class AIOBulbScanner(BulbScanner):
         sock = self._create_socket()
         destination = self._destination_from_address(address)
         found_all_future: "asyncio.Future[bool]" = asyncio.Future()
-        response_list: Dict[str, FluxLEDDiscovery] = {}
 
         def _on_response(data: bytes, addr: Tuple[str, int]) -> None:
             _LOGGER.debug("discover: %s <= %s", addr, data)
-            if self._process_response(data, addr, address, response_list):
+            if self._process_response(data, addr, address, self._discoveries):
                 with contextlib.suppress(asyncio.InvalidStateError):
                     found_all_future.set_result(True)
 
@@ -100,5 +99,4 @@ class AIOBulbScanner(BulbScanner):
         finally:
             transport.close()
 
-        self.found_bulbs = self._found_bulbs(response_list)
-        return list(self.found_bulbs)
+        return self.found_bulbs

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -9,9 +9,6 @@ from .scanner import BulbScanner, FluxLEDDiscovery
 _LOGGER = logging.getLogger(__name__)
 
 
-MAX_UPDATES_WITHOUT_RESPONSE = 4
-
-
 class LEDENETDiscovery(asyncio.DatagramProtocol):
     def __init__(
         self,


### PR DESCRIPTION
- If multiple discoveries were running at the same time in the
  same AIOBulbScanner they would overwrite self.found_bulb.
  The data is now combined to ensure bulbs on all networks
  are discovered