### PR TITLE
Fix exception when device 2x about strip config

### DIFF
--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -413,7 +413,8 @@ class AIOWifiLedBulb(LEDENETDevice):
             hex(msg[5]),
             self._segments,
         )
-        self._ic_future.set_result(True)
+        if not self._ic_future.done():
+            self._ic_future.set_result(True)
         return True
 
     def process_addressable_response(self, msg: bytes) -> bool:

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -512,7 +512,12 @@ async def test_async_set_zones(mock_aio_protocol, caplog: pytest.LogCaptureFixtu
     )
     # ic state
     light._aio_protocol.data_received(b"\x00\x63\x00\x19\x00\x02\x04\x03\x19\x02\xA0")
+    # sometimes the devices responds 2x
+    light._aio_protocol.data_received(b"\x00\x63\x00\x19\x00\x02\x04\x03\x19\x02\xA0")
+
     await task
+    assert light._pixels_per_segment == 25
+    assert light._segments == 2
     assert light.model_num == 0xA3
     assert light.dimmable_effects is True
     assert light.requires_turn_on is False


### PR DESCRIPTION
Fixes
```
2021-12-08 10:33:10 ERROR (MainThread) [homeassistant] Error doing job: Fatal error: protocol.data_received() call failed.
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/selector_events.py", line 870, in _read_ready__data_received
    self._protocol.data_received(data)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/flux_led/aioprotocol.py", line 57, in data_received
    self._data_receive_callback(data)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/flux_led/aiodevice.py", line 359, in _async_data_recieved
    self._async_process_message(msg)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/flux_led/aiodevice.py", line 384, in _async_process_message
    self.process_ic_response(msg)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/flux_led/aiodevice.py", line 416, in process_ic_response
    self._ic_future.set_result(True)
asyncio.exceptions.InvalidStateError: invalid state
2021-12-08 10:33:10 DEBUG (MainThread) [flux_led.aioprotocol] (192.168.106.60, 5577): Connection lost: invalid state```