### PR TITLE
Add support for remote access config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ in PyQt, Kivy, or some other framework.
 * Setting timers
 * Sync clock
 * Music Mode for devices with a built-in microphone (asyncio version only)
+* Remote access administration (asyncio version only)
 	
 ##### Some missing pieces:
 * Initial administration to set up WiFi SSID and passphrase/key.
-* Remote access administration
 	  
 ##### Cool feature:
 * Specify colors with names or web hex values.  Requires that python "webcolors" 

--- a/examples/disable_remote_access.py
+++ b/examples/disable_remote_access.py
@@ -1,0 +1,15 @@
+import asyncio
+import logging
+import pprint
+
+from flux_led.aioscanner import AIOBulbScanner
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+async def go():
+    scanner = AIOBulbScanner()
+    pprint.pprint(await scanner.async_disable_remote_access("192.168.106.198"))
+
+
+asyncio.run(go())

--- a/examples/enable_remote_access.py
+++ b/examples/enable_remote_access.py
@@ -1,0 +1,19 @@
+import asyncio
+import logging
+import pprint
+
+from flux_led.aioscanner import AIOBulbScanner
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+async def go():
+    scanner = AIOBulbScanner()
+    pprint.pprint(
+        await scanner.async_enable_remote_access(
+            "192.168.106.198", "ra8815us02.magichue.net", 8815
+        )
+    )
+
+
+asyncio.run(go())

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -358,7 +358,7 @@ class AIOWifiLedBulb(LEDENETDevice):
     ) -> None:
         """Enable remote access."""
         await AIOBulbScanner().async_enable_remote_access(
-            self.ipaddr, remote_access_host, remote_access_host
+            self.ipaddr, remote_access_host, remote_access_port
         )
 
     async def async_disable_remote_access(self) -> None:

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -9,6 +9,7 @@ from flux_led.protocol import (
     ProtocolLEDENETAddressableA3,
     ProtocolLEDENETOriginal,
 )
+from .aioscanner import AIOBulbScanner
 
 from .aioprotocol import AIOLEDENETProtocol
 from .base_device import PROTOCOL_PROBES, LEDENETDevice
@@ -351,6 +352,18 @@ class AIOWifiLedBulb(LEDENETDevice):
         if self.color_mode == COLOR_MODE_DIM:
             await self.async_set_levels(w=brightness)
             return
+
+    async def async_enable_remote_access(
+        self, remote_access_host: str, remote_access_port: int
+    ) -> None:
+        """Enable remote access."""
+        await AIOBulbScanner().async_enable_remote_access(
+            self.ipaddr, remote_access_host, remote_access_host
+        )
+
+    async def async_disable_remote_access(self) -> None:
+        """Disable remote access."""
+        await AIOBulbScanner().async_disable_remote_access(self.ipaddr)
 
     async def _async_connect(self) -> None:
         """Create connection."""

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -9,9 +9,9 @@ from flux_led.protocol import (
     ProtocolLEDENETAddressableA3,
     ProtocolLEDENETOriginal,
 )
-from .aioscanner import AIOBulbScanner
 
 from .aioprotocol import AIOLEDENETProtocol
+from .aioscanner import AIOBulbScanner
 from .base_device import PROTOCOL_PROBES, LEDENETDevice
 from .const import (
     COLOR_MODE_CCT,

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -104,7 +104,7 @@ class AIOBulbScanner(BulbScanner):
             self.send_disable_remote_access_message, address, timeout
         )
 
-    async def async_disable_remote_access(
+    async def async_enable_remote_access(
         self,
         address: str,
         remote_access_host: str,

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import logging
 import time
-from typing import Callable, Coroutine, List, Optional, Tuple, cast
+from typing import Callable, List, Optional, Tuple, cast
 
 from .scanner import BulbScanner, FluxLEDDiscovery
 

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import logging
 import time
-from typing import Callable, List, Optional, Tuple, cast
+from typing import Callable, Coroutine, List, Optional, Tuple, cast
 
 from .scanner import BulbScanner, FluxLEDDiscovery
 
@@ -97,3 +97,63 @@ class AIOBulbScanner(BulbScanner):
             transport.close()
 
         return self.found_bulbs
+
+    async def async_disable_remote_access(self, address: str, timeout: int = 5) -> None:
+        """Disable remote access."""
+        await self._send_command_and_reboot(
+            self.send_disable_remote_access_message, address, timeout
+        )
+
+    async def async_disable_remote_access(
+        self,
+        address: str,
+        remote_access_host: str,
+        remote_access_port: int,
+        timeout: int = 5,
+    ) -> None:
+        """Enable remote access."""
+
+        def _enable_remote_access_message(
+            sender: asyncio.DatagramTransport, destination: Tuple[str, int]
+        ) -> None:
+            self.send_enable_remote_access_message(
+                sender, destination, remote_access_host, remote_access_port
+            )
+
+        await self._send_command_and_reboot(
+            _enable_remote_access_message, address, timeout
+        )
+
+    async def _send_command_and_reboot(
+        self,
+        msg_sender: Callable[[asyncio.DatagramTransport, Tuple[str, int]], None],
+        address: str,
+        timeout: int = 5,
+    ) -> None:
+        """Send a command and reboot."""
+        sock = self._create_socket()
+        destination = self._destination_from_address(address)
+        responded = asyncio.Event()
+
+        def _on_response(data: bytes, addr: Tuple[str, int]) -> None:
+            _LOGGER.debug("udp: %s <= %s", addr, data)
+            if data.startswith(b"+ok"):
+                responded.set()
+
+        transport_proto = await self.loop.create_datagram_endpoint(
+            lambda: LEDENETDiscovery(
+                destination=destination,
+                on_response=_on_response,
+            ),
+            sock=sock,
+        )
+        transport = cast(asyncio.DatagramTransport, transport_proto[0])
+        try:
+            self.send_start_message(transport, destination)
+            msg_sender(transport, destination)
+            await asyncio.wait_for(responded.wait(), timeout=timeout)
+            responded.clear()
+            self.send_reboot_message(transport, destination)
+            await asyncio.wait_for(responded.wait(), timeout=timeout)
+        finally:
+            transport.close()

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -97,7 +97,8 @@ def _process_remote_access_message(data: FluxLEDDiscovery, decoded_data: str) ->
     """
     data_split = decoded_data.replace("\r", "").split(",")
     if len(data_split) < 3:
-        data["remote_access_enabled"] = False
+        if not data.get("remote_access_enabled"):
+            data["remote_access_enabled"] = False
         return
     try:
         data.update(
@@ -196,7 +197,11 @@ class BulbScanner:
                 remote_access_port=None,
             ),
         )
-        if decoded_data.startswith("+ok=T") or decoded_data.startswith("+ok=N"):
+        if (
+            decoded_data.startswith("+ok=T")
+            or decoded_data == "+ok="
+            or decoded_data == "+ok=\r"
+        ):
             _process_remote_access_message(data, decoded_data)
         if decoded_data.startswith("+ok="):
             _process_version_message(data, decoded_data)

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -91,7 +91,7 @@ def _process_version_message(data: FluxLEDDiscovery, decoded_data: str) -> None:
 
 
 def _process_remote_access_message(data: FluxLEDDiscovery, decoded_data: str) -> None:
-    """Process response from b'HF-A11ASSISTHREAD'
+    """Process response from b'AT+SOCKB\r'
 
     b'+ok=TCP,8816,ra8816us02.magichue.net\r'
     """

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -1155,7 +1155,7 @@ async def test_async_scanner(mock_discovery_aio_protocol):
     )
     protocol.datagram_received(
         b"+ok=TCP,GARBAGE,ra8816us02.magichue.net\r", ("192.168.213.252", 48899)
-    )    
+    )
     protocol.datagram_received(
         b"+ok=TCP,8816,ra8816us02.magichue.net\r", ("192.168.213.252", 48899)
     )

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -1093,6 +1093,9 @@ async def test_async_scanner(mock_discovery_aio_protocol):
     protocol.datagram_received(
         b"192.168.213.252,B4E842E10588,AK001-ZJ2145", ("192.168.213.252", 48899)
     )
+    protocol.datagram_received(
+        b"+ok=TCP,8816,ra8816us02.magichue.net\r", ("192.168.213.252", 48899)
+    )
     protocol.datagram_received(b"AT+LVER\r", ("127.0.0.1", 48899))
     protocol.datagram_received(
         b"+ok=08_15_20210204_ZG-BL\r", ("192.168.213.252", 48899)
@@ -1100,7 +1103,9 @@ async def test_async_scanner(mock_discovery_aio_protocol):
     protocol.datagram_received(
         b"192.168.213.65,F4CFA23E1AAF,AK001-ZJ2104", ("192.168.213.65", 48899)
     )
+    protocol.datagram_received(b"+ok=", ("192.168.213.65", 48899))
     protocol.datagram_received(b"+ok=A2_33_20200428_ZG-LX\r", ("192.168.213.65", 48899))
+
     data = await task
     assert data == [
         {
@@ -1112,6 +1117,9 @@ async def test_async_scanner(mock_discovery_aio_protocol):
             "model_info": "ZG-BL",
             "model_num": 8,
             "version_num": 21,
+            "remote_access_enabled": True,
+            "remote_access_host": "ra8816us02.magichue.net",
+            "remote_access_port": 8816,
         },
         {
             "firmware_date": datetime.date(2020, 4, 28),
@@ -1122,6 +1130,9 @@ async def test_async_scanner(mock_discovery_aio_protocol):
             "model_info": "ZG-LX",
             "model_num": 162,
             "version_num": 51,
+            "remote_access_enabled": False,
+            "remote_access_host": None,
+            "remote_access_port": None,
         },
     ]
 
@@ -1141,6 +1152,9 @@ async def test_async_scanner_specific_address(mock_discovery_aio_protocol):
     protocol.datagram_received(
         b"+ok=08_15_20210204_ZG-BL\r", ("192.168.213.252", 48899)
     )
+    protocol.datagram_received(
+        b"+ok=TCP,8816,ra8816us02.magichue.net\r", ("192.168.213.252", 48899)
+    )
     data = await task
     assert data == [
         {
@@ -1152,6 +1166,9 @@ async def test_async_scanner_specific_address(mock_discovery_aio_protocol):
             "model_info": "ZG-BL",
             "model_num": 8,
             "version_num": 21,
+            "remote_access_enabled": True,
+            "remote_access_host": "ra8816us02.magichue.net",
+            "remote_access_port": 8816,
         }
     ]
     assert scanner.getBulbInfoByID("B4E842E10588") == {
@@ -1163,6 +1180,9 @@ async def test_async_scanner_specific_address(mock_discovery_aio_protocol):
         "model_info": "ZG-BL",
         "model_num": 8,
         "version_num": 21,
+        "remote_access_enabled": True,
+        "remote_access_host": "ra8816us02.magichue.net",
+        "remote_access_port": 8816,
     }
     assert scanner.getBulbInfo() == [
         {
@@ -1174,6 +1194,9 @@ async def test_async_scanner_specific_address(mock_discovery_aio_protocol):
             "model_info": "ZG-BL",
             "model_num": 8,
             "version_num": 21,
+            "remote_access_enabled": True,
+            "remote_access_host": "ra8816us02.magichue.net",
+            "remote_access_port": 8816,
         }
     ]
 

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -1154,6 +1154,9 @@ async def test_async_scanner(mock_discovery_aio_protocol):
         b"192.168.213.252,B4E842E10588,AK001-ZJ2145", ("192.168.213.252", 48899)
     )
     protocol.datagram_received(
+        b"+ok=TCP,GARBAGE,ra8816us02.magichue.net\r", ("192.168.213.252", 48899)
+    )    
+    protocol.datagram_received(
         b"+ok=TCP,8816,ra8816us02.magichue.net\r", ("192.168.213.252", 48899)
     )
     protocol.datagram_received(b"AT+LVER\r", ("127.0.0.1", 48899))

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -47,6 +47,16 @@ FLUX_DISCOVERY = FluxLEDDiscovery(
 )
 
 
+def mock_coro(return_value=None, exception=None):
+    """Return a coro that returns a value or raise an exception."""
+    fut = asyncio.Future()
+    if exception is not None:
+        fut.set_exception(exception)
+    else:
+        fut.set_result(return_value)
+    return fut
+
+
 @pytest.fixture
 async def mock_discovery_aio_protocol():
     """Fixture to mock an asyncio connection."""
@@ -1096,7 +1106,8 @@ async def test_async_enable_remote_access(mock_aio_protocol):
     await task
 
     with patch(
-        "flux_led.aiodevice.AIOBulbScanner.async_enable_remote_access"
+        "flux_led.aiodevice.AIOBulbScanner.async_enable_remote_access",
+        return_value=mock_coro(True),
     ) as mock_async_enable_remote_access:
         await light.async_enable_remote_access("host", 1234)
 
@@ -1121,7 +1132,8 @@ async def test_async_disable_remote_access(mock_aio_protocol):
     await task
 
     with patch(
-        "flux_led.aiodevice.AIOBulbScanner.async_disable_remote_access"
+        "flux_led.aiodevice.AIOBulbScanner.async_disable_remote_access",
+        return_value=mock_coro(True),
     ) as mock_async_disable_remote_access:
         await light.async_disable_remote_access()
 


### PR DESCRIPTION
- We should be able to add a switch to shut off the cloud connection in Home Assistant
- We need to store the remote host and port before we shut it off so we can turn it back on.. some might need a `\r`

```

— Query Remote Access —
AT+SOCKB
+ok=TCP,8816,ra8816us02.magichue.net
AT+Z
+ok

— Enable Remote Access —
AT+SOCKB=TCP,8816,ra8816us02.magichue.net
+ok
AT+Z
+ok

— Disable Remote Access —
AT+SOCKB=NONE
+ok
AT+Z
+ok

```