### PR TITLE
Fix firmware parser and device scanner with older versions

### DIFF
--- a/examples/scanner.py
+++ b/examples/scanner.py
@@ -1,0 +1,9 @@
+import logging
+import pprint
+
+from flux_led.scanner import BulbScanner
+
+logging.basicConfig(level=logging.DEBUG)
+
+pprint.pprint(BulbScanner().scan(timeout=10))
+

--- a/examples/scanner.py
+++ b/examples/scanner.py
@@ -6,4 +6,3 @@ from flux_led.scanner import BulbScanner
 logging.basicConfig(level=logging.DEBUG)
 
 pprint.pprint(BulbScanner().scan(timeout=10))
-

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -191,5 +191,5 @@ class AIOBulbScanner(BulbScanner):
         )
 
     async def async_reboot(self, address: str, timeout: int = 5) -> None:
-        """Disable remote access."""
+        """Reboot the device."""
         await self._async_send_commands_and_reboot(None, address, timeout)

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import Callable, Dict, List, Optional, Tuple, cast
 
-from .scanner import BulbScanner, FluxLEDDiscovery, MESSAGE_SEND_INTERLEAVE_DELAY
+from .scanner import MESSAGE_SEND_INTERLEAVE_DELAY, BulbScanner, FluxLEDDiscovery
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -41,10 +41,10 @@ class AIOBulbScanner(BulbScanner):
 
     async def _async_send_messages(
         self,
-        messages: list[bytes],
+        messages: List[bytes],
         sender: asyncio.DatagramTransport,
         destination: Tuple[str, int],
-    ):
+    ) -> None:
         """Send messages with a short delay between them."""
         last_idx = len(messages) - 1
         for idx, message in enumerate(messages):
@@ -72,7 +72,7 @@ class AIOBulbScanner(BulbScanner):
 
     async def _async_send_commands_and_reboot(
         self,
-        messages: Optional[list[bytes]],
+        messages: Optional[List[bytes]],
         address: str,
         timeout: int = 5,
     ) -> None:
@@ -94,7 +94,7 @@ class AIOBulbScanner(BulbScanner):
             sock=sock,
         )
         transport = cast(asyncio.DatagramTransport, transport_proto[0])
-        commands: Optional[list[bytes]] = []
+        commands: List[bytes] = []
         if messages:
             commands.extend(messages)
         commands.extend(self.get_reboot_messages())

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -97,10 +97,10 @@ class AIOBulbScanner(BulbScanner):
         commands: List[bytes] = []
         if messages:
             commands.extend(messages)
-        commands.extend(self.get_reboot_messages())
+        commands.extend(self._get_reboot_messages())
         try:
             await self._async_send_messages(
-                self.get_start_messages(), transport, destination
+                self._get_start_messages(), transport, destination
             )
             await self._async_send_and_wait(
                 events, commands, transport, destination, timeout
@@ -171,7 +171,7 @@ class AIOBulbScanner(BulbScanner):
     async def async_disable_remote_access(self, address: str, timeout: int = 5) -> None:
         """Disable remote access."""
         await self._async_send_commands_and_reboot(
-            self.get_disable_remote_access_messages(), address, timeout
+            self._get_disable_remote_access_messages(), address, timeout
         )
 
     async def async_enable_remote_access(
@@ -183,7 +183,7 @@ class AIOBulbScanner(BulbScanner):
     ) -> None:
         """Enable remote access."""
         await self._async_send_commands_and_reboot(
-            self.get_enable_remote_access_messages(
+            self._get_enable_remote_access_messages(
                 remote_access_host, remote_access_port
             ),
             address,

--- a/flux_led/fluxled.py
+++ b/flux_led/fluxled.py
@@ -688,7 +688,7 @@ def main() -> None:  # noqa: C901
 
     if options.scan:
         scanner = BulbScanner()
-        scanner.scan(timeout=2)
+        scanner.scan(timeout=6)
         bulb_info_list = scanner.getBulbInfo()
         # we have a list of buld info dicts
         addrs = []

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -244,7 +244,7 @@ class BulbScanner:
         self,
         remote_access_host: str,
         remote_access_port: int,
-    ) -> None:
+    ) -> List[bytes]:
         enable_message = f"AT+SOCKB=TCP,{remote_access_port},{remote_access_host}\r"
         return [enable_message.encode()]
 
@@ -255,7 +255,7 @@ class BulbScanner:
 
     def get_reboot_messages(
         self,
-    ) -> None:
+    ) -> List[bytes]:
         return [self.REBOOT_MESSAGE]
 
     def _send_message(
@@ -269,10 +269,10 @@ class BulbScanner:
 
     def _send_messages(
         self,
-        messages: list[bytes],
+        messages: List[bytes],
         sender: Union[socket.socket, asyncio.DatagramTransport],
         destination: Tuple[str, int],
-    ):
+    ) -> None:
         """Send messages with a short delay between them."""
         for idx, message in enumerate(messages):
             self._send_message(sender, destination, message)

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -30,7 +30,7 @@ from .models_db import get_model_description
 
 _LOGGER = logging.getLogger(__name__)
 
-MESSAGE_SEND_INTERLEAVE_DELAY = 0.1
+MESSAGE_SEND_INTERLEAVE_DELAY = 0.25
 
 
 class FluxLEDDiscovery(TypedDict):
@@ -89,7 +89,7 @@ def _process_version_message(data: FluxLEDDiscovery, decoded_data: str) -> None:
     b'+ok=07_06_20210106_ZG-BL\r'
     """
     version_data = decoded_data[4:].replace("\r", "")
-    data_split = version_data.split("_")
+    data_split = version_data.split("_", 4)
     if len(data_split) < 2:
         return
     try:
@@ -109,9 +109,8 @@ def _process_version_message(data: FluxLEDDiscovery, decoded_data: str) -> None:
         )
     except (TypeError, ValueError):
         return
-    if len(data_split) < 4:
-        return
-    data[ATTR_MODEL_INFO] = data_split[3]
+    if len(data_split) == 4:
+        data[ATTR_MODEL_INFO] = data_split[3]
     data[ATTR_MODEL_DESCRIPTION] = get_model_description(
         cast(int, data[ATTR_MODEL_NUM]), data[ATTR_MODEL_INFO]
     )

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -30,7 +30,7 @@ from .models_db import get_model_description
 
 _LOGGER = logging.getLogger(__name__)
 
-MESSAGE_SEND_INTERLEAVE_DELAY = 0.25
+MESSAGE_SEND_INTERLEAVE_DELAY = 0.5
 
 
 class FluxLEDDiscovery(TypedDict):

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -5,7 +5,7 @@ import select
 import socket
 import sys
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 from .const import (
     ATTR_FIRMWARE_DATE,
@@ -235,12 +235,12 @@ class BulbScanner:
         elif "," in decoded_data:
             _process_discovery_message(data, decoded_data)
 
-    def get_start_messages(
+    def _get_start_messages(
         self,
     ) -> List[bytes]:
         return [self.DISCOVER_MESSAGE]
 
-    def get_enable_remote_access_messages(
+    def _get_enable_remote_access_messages(
         self,
         remote_access_host: str,
         remote_access_port: int,
@@ -248,12 +248,12 @@ class BulbScanner:
         enable_message = f"AT+SOCKB=TCP,{remote_access_port},{remote_access_host}\r"
         return [enable_message.encode()]
 
-    def get_disable_remote_access_messages(
+    def _get_disable_remote_access_messages(
         self,
     ) -> List[bytes]:
         return [self.DISABLE_REMOTE_ACCESS_MESSAGE]
 
-    def get_reboot_messages(
+    def _get_reboot_messages(
         self,
     ) -> List[bytes]:
         return [self.REBOOT_MESSAGE]

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from datetime import date
 import logging
 import select
@@ -100,14 +101,12 @@ def _process_version_message(data: FluxLEDDiscovery, decoded_data: str) -> None:
     assert data[ATTR_MODEL_NUM] is not None
     if len(data_split) >= 3:
         firmware_date = data_split[2]
-        try:
+        with contextlib.suppress((TypeError, ValueError)):
             data[ATTR_FIRMWARE_DATE] = date(
                 int(firmware_date[:4]),
                 int(firmware_date[4:6]),
                 int(firmware_date[6:8]),
             )
-        except (TypeError, ValueError):
-            return
     if len(data_split) == 4:
         data[ATTR_MODEL_INFO] = data_split[3]
     data[ATTR_MODEL_DESCRIPTION] = get_model_description(

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -31,7 +31,7 @@ from .models_db import get_model_description
 
 _LOGGER = logging.getLogger(__name__)
 
-MESSAGE_SEND_INTERLEAVE_DELAY = 0.5
+MESSAGE_SEND_INTERLEAVE_DELAY = 0.4
 
 
 class FluxLEDDiscovery(TypedDict):

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -101,7 +101,7 @@ def _process_version_message(data: FluxLEDDiscovery, decoded_data: str) -> None:
     assert data[ATTR_MODEL_NUM] is not None
     if len(data_split) >= 3:
         firmware_date = data_split[2]
-        with contextlib.suppress((TypeError, ValueError)):
+        with contextlib.suppress(TypeError, ValueError):
             data[ATTR_FIRMWARE_DATE] = date(
                 int(firmware_date[:4]),
                 int(firmware_date[4:6]),

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extra_requirements = {
 setup(
     name="flux_led",
     packages=["flux_led"],
-    version="0.27.6",
+    version="0.27.7",
     description="A Python library to communicate with the flux_led smart bulbs",
     author="Daniel Hjelseth Høyer",
     author_email="mail@dahoiv.net",

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from flux_led import aiodevice
+from flux_led import aioscanner
 from flux_led.aio import AIOWifiLedBulb
 from flux_led.aioprotocol import AIOLEDENETProtocol
 from flux_led.aioscanner import AIOBulbScanner, LEDENETDiscovery
@@ -86,7 +87,7 @@ async def mock_discovery_aio_protocol():
             future.set_result((transport, protocol))
         return transport, protocol
 
-    with patch.object(loop, "create_datagram_endpoint", _mock_create_datagram_endpoint):
+    with patch.object(loop, "create_datagram_endpoint", _mock_create_datagram_endpoint), patch.object(aioscanner, "MESSAGE_SEND_INTERLEAVE_DELAY", 0):
         yield _wait_for_connection
 
 

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -1565,6 +1565,9 @@ async def test_async_scanner(mock_discovery_aio_protocol):
         b"192.168.198.197,B4E842E10521,AK001-ZJ2146", ("192.168.198.197", 48899)
     )
     protocol.datagram_received(
+        b"192.168.198.196,B4E842E10520,AK001-ZJ2144", ("192.168.198.196", 48899)
+    )
+    protocol.datagram_received(
         b"+ok=TCP,GARBAGE,ra8816us02.magichue.net\r", ("192.168.213.252", 48899)
     )
     protocol.datagram_received(
@@ -1579,6 +1582,8 @@ async def test_async_scanner(mock_discovery_aio_protocol):
     )
     protocol.datagram_received(b"+ok=52_3_20210204\r", ("192.168.198.198", 48899))
     protocol.datagram_received(b"+ok=62_3\r", ("192.168.198.197", 48899))
+    protocol.datagram_received(b"+ok=41_3_202\r", ("192.168.198.196", 48899))
+
     protocol.datagram_received(
         b"+ok=35_62_20210109_ZG-BL-PWM\r", ("192.168.213.259", 48899)
     )
@@ -1588,7 +1593,9 @@ async def test_async_scanner(mock_discovery_aio_protocol):
     protocol.datagram_received(b"+ok=", ("192.168.213.65", 48899))
     protocol.datagram_received(b"+ok=A2_33_20200428_ZG-LX\r", ("192.168.213.65", 48899))
     protocol.datagram_received(b"+ok=", ("192.168.213.259", 48899))
-
+    protocol.datagram_received(
+        b"+ok=TCP,8816,ra8816us02.magichue.net\r", ("192.168.198.196", 48899)
+    )
     data = await task
     assert data == [
         {
@@ -1628,6 +1635,19 @@ async def test_async_scanner(mock_discovery_aio_protocol):
             "remote_access_enabled": None,
             "remote_access_host": None,
             "remote_access_port": None,
+            "version_num": 3,
+        },
+        {
+            "firmware_date": None,
+            "id": "B4E842E10520",
+            "ipaddr": "192.168.198.196",
+            "model": "AK001-ZJ2144",
+            "model_description": "Controller Dimmable",
+            "model_info": None,
+            "model_num": 65,
+            "remote_access_enabled": True,
+            "remote_access_host": "ra8816us02.magichue.net",
+            "remote_access_port": 8816,
             "version_num": 3,
         },
         {

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -6,8 +6,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from flux_led import aiodevice
-from flux_led import aioscanner
+from flux_led import aiodevice, aioscanner
 from flux_led.aio import AIOWifiLedBulb
 from flux_led.aioprotocol import AIOLEDENETProtocol
 from flux_led.aioscanner import AIOBulbScanner, LEDENETDiscovery
@@ -87,7 +86,9 @@ async def mock_discovery_aio_protocol():
             future.set_result((transport, protocol))
         return transport, protocol
 
-    with patch.object(loop, "create_datagram_endpoint", _mock_create_datagram_endpoint), patch.object(aioscanner, "MESSAGE_SEND_INTERLEAVE_DELAY", 0):
+    with patch.object(
+        loop, "create_datagram_endpoint", _mock_create_datagram_endpoint
+    ), patch.object(aioscanner, "MESSAGE_SEND_INTERLEAVE_DELAY", 0):
         yield _wait_for_connection
 
 
@@ -1562,7 +1563,7 @@ async def test_async_scanner(mock_discovery_aio_protocol):
     )
     protocol.datagram_received(
         b"192.168.198.197,B4E842E10521,AK001-ZJ2146", ("192.168.198.197", 48899)
-    )    
+    )
     protocol.datagram_received(
         b"+ok=TCP,GARBAGE,ra8816us02.magichue.net\r", ("192.168.213.252", 48899)
     )
@@ -1576,12 +1577,8 @@ async def test_async_scanner(mock_discovery_aio_protocol):
     protocol.datagram_received(
         b"+ok=08_15_20210204_ZG-BL\r", ("192.168.213.252", 48899)
     )
-    protocol.datagram_received(
-        b"+ok=52_3_20210204\r", ("192.168.198.198", 48899)
-    )    
-    protocol.datagram_received(
-        b"+ok=62_3\r", ("192.168.198.197", 48899)
-    )        
+    protocol.datagram_received(b"+ok=52_3_20210204\r", ("192.168.198.198", 48899))
+    protocol.datagram_received(b"+ok=62_3\r", ("192.168.198.197", 48899))
     protocol.datagram_received(
         b"+ok=35_62_20210109_ZG-BL-PWM\r", ("192.168.213.259", 48899)
     )
@@ -1593,61 +1590,73 @@ async def test_async_scanner(mock_discovery_aio_protocol):
     protocol.datagram_received(b"+ok=", ("192.168.213.259", 48899))
 
     data = await task
-    assert data == [{'firmware_date': datetime.date(2021, 2, 4),
-        'id': 'B4E842E10588',
-        'ipaddr': '192.168.213.252',
-        'model': 'AK001-ZJ2145',
-        'model_description': 'Controller RGB with MIC',
-        'model_info': 'ZG-BL',
-        'model_num': 8,
-        'remote_access_enabled': True,
-        'remote_access_host': 'ra8816us02.magichue.net',
-        'remote_access_port': 8816,
-        'version_num': 21},
-        {'firmware_date': datetime.date(2021, 2, 4),
-        'id': 'B4E842E10522',
-        'ipaddr': '192.168.198.198',
-        'model': 'AK001-ZJ2149',
-        'model_description': 'Bulb CCT',
-        'model_info': None,
-        'model_num': 82,
-        'remote_access_enabled': None,
-        'remote_access_host': None,
-        'remote_access_port': None,
-        'version_num': 3},
-        {'firmware_date': None,
-        'id': 'B4E842E10521',
-        'ipaddr': '192.168.198.197',
-        'model': 'AK001-ZJ2146',
-        'model_description': 'Controller CCT',
-        'model_info': None,
-        'model_num': 98,
-        'remote_access_enabled': None,
-        'remote_access_host': None,
-        'remote_access_port': None,
-        'version_num': 3},
-        {'firmware_date': datetime.date(2021, 1, 9),
-        'id': 'B4E842E10586',
-        'ipaddr': '192.168.213.259',
-        'model': 'AK001-ZJ2145',
-        'model_description': 'Bulb RGBCW Flood',
-        'model_info': 'ZG-BL-PWM',
-        'model_num': 53,
-        'remote_access_enabled': False,
-        'remote_access_host': None,
-        'remote_access_port': None,
-        'version_num': 98},
-        {'firmware_date': datetime.date(2020, 4, 28),
-        'id': 'F4CFA23E1AAF',
-        'ipaddr': '192.168.213.65',
-        'model': 'AK001-ZJ2104',
-        'model_description': 'Addressable v2',
-        'model_info': 'ZG-LX',
-        'model_num': 162,
-        'remote_access_enabled': False,
-        'remote_access_host': None,
-        'remote_access_port': None,
-        'version_num': 51}]
+    assert data == [
+        {
+            "firmware_date": datetime.date(2021, 2, 4),
+            "id": "B4E842E10588",
+            "ipaddr": "192.168.213.252",
+            "model": "AK001-ZJ2145",
+            "model_description": "Controller RGB with MIC",
+            "model_info": "ZG-BL",
+            "model_num": 8,
+            "remote_access_enabled": True,
+            "remote_access_host": "ra8816us02.magichue.net",
+            "remote_access_port": 8816,
+            "version_num": 21,
+        },
+        {
+            "firmware_date": datetime.date(2021, 2, 4),
+            "id": "B4E842E10522",
+            "ipaddr": "192.168.198.198",
+            "model": "AK001-ZJ2149",
+            "model_description": "Bulb CCT",
+            "model_info": None,
+            "model_num": 82,
+            "remote_access_enabled": None,
+            "remote_access_host": None,
+            "remote_access_port": None,
+            "version_num": 3,
+        },
+        {
+            "firmware_date": None,
+            "id": "B4E842E10521",
+            "ipaddr": "192.168.198.197",
+            "model": "AK001-ZJ2146",
+            "model_description": "Controller CCT",
+            "model_info": None,
+            "model_num": 98,
+            "remote_access_enabled": None,
+            "remote_access_host": None,
+            "remote_access_port": None,
+            "version_num": 3,
+        },
+        {
+            "firmware_date": datetime.date(2021, 1, 9),
+            "id": "B4E842E10586",
+            "ipaddr": "192.168.213.259",
+            "model": "AK001-ZJ2145",
+            "model_description": "Bulb RGBCW Flood",
+            "model_info": "ZG-BL-PWM",
+            "model_num": 53,
+            "remote_access_enabled": False,
+            "remote_access_host": None,
+            "remote_access_port": None,
+            "version_num": 98,
+        },
+        {
+            "firmware_date": datetime.date(2020, 4, 28),
+            "id": "F4CFA23E1AAF",
+            "ipaddr": "192.168.213.65",
+            "model": "AK001-ZJ2104",
+            "model_description": "Addressable v2",
+            "model_info": "ZG-LX",
+            "model_num": 162,
+            "remote_access_enabled": False,
+            "remote_access_host": None,
+            "remote_access_port": None,
+            "version_num": 51,
+        },
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- A delay is needed between sending messages to avoid overloading the devices