### PR TITLE
Only accept a power state response as success on the accept_any_powerfix_accepting_state_response

### DIFF
--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -206,12 +206,11 @@ class AIOWifiLedBulb(LEDENETDevice):
             [state_future, power_state_future], state
         ):
             return True
-        responded = power_state_future.done() or state_future.done()
-        if responded and accept_any_power_state_response:
+        if power_state_future.done() and accept_any_power_state_response:
             # The magic home app will accept any response as success
             # so after a few tries, we do as well.
             return True
-        elif responded:
+        elif power_state_future.done() or state_future.done():
             _LOGGER.debug(
                 "%s: Bulb power state change taking longer than expected to %s, sending state query",
                 self.ipaddr,

--- a/tests_aio.py
+++ b/tests_aio.py
@@ -441,6 +441,13 @@ async def test_turn_on_off(mock_aio_protocol, caplog: pytest.LogCaptureFixture):
             light.is_on is True
         )  # transition time should now be in effect since we forced state
 
+        data = [*(b"\x81\x25\x23\x61\x05\x10\xb6\x00\x98\x19\x04\x25\x0f\xde",) * 10]
+        await light.async_turn_off()
+        await asyncio.sleep(0)
+        # If all we get is on 0x81 responses, the bulb failed to turn off
+        assert light.is_on is True
+        assert len(data) == 2
+
     await asyncio.sleep(0)
     caplog.clear()
     caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
- Since the Magic Home app accepts any power state response to
  a turn on, we do as well after trying multiple times to make
  sure the device turns on.  We do not want to accept a 0x81
  state response however