### PR TITLE
Create futures using loop.create_future()

### DIFF
--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -144,7 +144,7 @@ class AIOBulbScanner(BulbScanner):
         """Discover LEDENET."""
         sock = self._create_socket()
         destination = self._destination_from_address(address)
-        found_all_future: "asyncio.Future[bool]" = asyncio.Future()
+        found_all_future: "asyncio.Future[bool]" = self.loop.create_future()
 
         def _on_response(data: bytes, addr: Tuple[str, int]) -> None:
             _LOGGER.debug("discover: %s <= %s", addr, data)


### PR DESCRIPTION
https://docs.python.org/3/library/asyncio-future.html#asyncio.Future

> The rule of thumb is to never expose Future objects in user-facing APIs, and the recommended way to create a Future object is to call loop.create_future(). This way alternative event loop implementations can inject their own optimized implementations of a Future object.