### PR TITLE
feat!: drop support for Python 3.7, 3.8, and 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.11
     hooks:
@@ -49,7 +49,7 @@ repos:
       - id: python-typing-update
         stages: [manual]
         args:
-          - --py39-plus
+          - --py310-plus
           - --force
           - --keep-updates
         files: ^(flux_led)/.+\.py$
@@ -70,12 +70,12 @@ repos:
           - --python-version=3.13
         files: ^(flux_led)/.+\.py$
       - id: mypy
-        alias: mypy-py39
-        name: MyPy, for Python 3.9
+        alias: mypy-py310
+        name: MyPy, for Python 3.10
         additional_dependencies:
           - async_timeout
           - pytest
           - webcolors
         args:
-          - --python-version=3.9
+          - --python-version=3.10
         files: ^(flux_led)/.+\.py$

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ in PyQt, Kivy, or some other framework.
 
 #### Minimum python version
 
-3.9
+3.10
 
 ##### Available:
 

--- a/examples/mockdevice.py
+++ b/examples/mockdevice.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import socket
-from typing import Optional
 
 from flux_led.aioscanner import AIOBulbScanner
 from flux_led.protocol import OUTER_MESSAGE_WRAPPER
@@ -38,7 +37,7 @@ class MagicHomeDiscoveryProtocol(asyncio.Protocol):
     def __init__(self) -> None:
         self.loop = asyncio.get_running_loop()
         self.local_ip = get_local_ip()
-        self.transport: Optional[asyncio.BaseTransport] = None
+        self.transport: asyncio.BaseTransport | None = None
 
     def connection_made(self, transport):
         self.transport = transport
@@ -76,11 +75,11 @@ class MagicHomeDiscoveryProtocol(asyncio.Protocol):
                 f"+ok={model_str}_{minor_version_str}_20210428_ZG-BL\r".encode(), addr
             )
 
-    def error_received(self, ex: Optional[Exception]) -> None:
+    def error_received(self, ex: Exception | None) -> None:
         """Handle error."""
         _LOGGER.debug("LEDENETDiscovery error: %s", ex)
 
-    def connection_lost(self, ex: Optional[Exception]) -> None:
+    def connection_lost(self, ex: Exception | None) -> None:
         """The connection is lost."""
 
 
@@ -91,7 +90,7 @@ class MagichomeServerProtocol(asyncio.Protocol):
         self.loop = asyncio.get_running_loop()
         self.handler = None
         self.peername = None
-        self.transport: Optional[asyncio.BaseTransport] = None
+        self.transport: asyncio.BaseTransport | None = None
 
     def connection_lost(self, exc: Exception) -> None:
         """Handle connection lost."""

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -4,8 +4,9 @@ import asyncio
 import logging
 import time
 from asyncio import ALL_COMPLETED, FIRST_COMPLETED
+from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any
 
 from .aioprotocol import AIOLEDENETProtocol
 from .aioscanner import AIOBulbScanner

--- a/flux_led/aioprotocol.py
+++ b/flux_led/aioprotocol.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from asyncio.transports import BaseTransport, WriteTransport
-from typing import Any, Callable, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/flux_led/aioscanner.py
+++ b/flux_led/aioscanner.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import logging
 import time
-from typing import Callable
+from collections.abc import Callable
 
 from .aioutils import asyncio_timeout
 from .scanner import MESSAGE_SEND_INTERLEAVE_DELAY, BulbScanner, FluxLEDDiscovery

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Iterable
 from dataclasses import asdict, is_dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from .const import (  # imported for back compat, remove once Home Assistant no longer uses
     ADDRESSABLE_STATE_CHANGE_LATENCY,
@@ -135,25 +135,25 @@ PROTOCOL_PROBES_LEGACY: tuple[
     type[ProtocolLEDENETOriginal], type[ProtocolLEDENET8Byte]
 ] = (ProtocolLEDENETOriginal, ProtocolLEDENET8Byte)
 
-PROTOCOL_TYPES = Union[
-    ProtocolLEDENET8Byte,
-    ProtocolLEDENET8ByteAutoOn,
-    ProtocolLEDENET8ByteDimmableEffects,
-    ProtocolLEDENET9Byte,
-    ProtocolLEDENET9ByteAutoOn,
-    ProtocolLEDENET9ByteDimmableEffects,
-    ProtocolLEDENET25Byte,
-    ProtocolLEDENETAddressableA1,
-    ProtocolLEDENETAddressableA2,
-    ProtocolLEDENETAddressableA3,
-    ProtocolLEDENETOriginal,
-    ProtocolLEDENETOriginalCCT,
-    ProtocolLEDENETOriginalRGBW,
-    ProtocolLEDENETCCT,
-    ProtocolLEDENETCCTWrapped,
-    ProtocolLEDENETSocket,
-    ProtocolLEDENETAddressableChristmas,
-]
+PROTOCOL_TYPES = (
+    ProtocolLEDENET8Byte
+    | ProtocolLEDENET8ByteAutoOn
+    | ProtocolLEDENET8ByteDimmableEffects
+    | ProtocolLEDENET9Byte
+    | ProtocolLEDENET9ByteAutoOn
+    | ProtocolLEDENET9ByteDimmableEffects
+    | ProtocolLEDENET25Byte
+    | ProtocolLEDENETAddressableA1
+    | ProtocolLEDENETAddressableA2
+    | ProtocolLEDENETAddressableA3
+    | ProtocolLEDENETOriginal
+    | ProtocolLEDENETOriginalCCT
+    | ProtocolLEDENETOriginalRGBW
+    | ProtocolLEDENETCCT
+    | ProtocolLEDENETCCTWrapped
+    | ProtocolLEDENETSocket
+    | ProtocolLEDENETAddressableChristmas
+)
 
 ADDRESSABLE_PROTOCOLS = {
     PROTOCOL_LEDENET_ADDRESSABLE_A1,

--- a/flux_led/scanner.py
+++ b/flux_led/scanner.py
@@ -6,9 +6,7 @@ import socket
 import time
 from datetime import date
 from typing import (
-    Optional,
     TypedDict,  # pylint: disable=no-name-in-module
-    Union,
 )
 
 from .const import (
@@ -36,19 +34,19 @@ class FluxLEDDiscovery(TypedDict):
     """A flux led device."""
 
     ipaddr: str
-    id: Optional[str]  # aka mac
-    model: Optional[str]
-    model_num: Optional[int]
-    version_num: Optional[int]
-    firmware_date: Optional[date]
-    model_info: Optional[str]  # contains if IR (and maybe BL) if the device supports IR
-    model_description: Optional[str]
-    remote_access_enabled: Optional[bool]
-    remote_access_host: Optional[str]  # the remote access host
-    remote_access_port: Optional[int]  # the remote access port
+    id: str | None  # aka mac
+    model: str | None
+    model_num: int | None
+    version_num: int | None
+    firmware_date: date | None
+    model_info: str | None  # contains if IR (and maybe BL) if the device supports IR
+    model_description: str | None
+    remote_access_enabled: bool | None
+    remote_access_host: str | None  # the remote access host
+    remote_access_port: int | None  # the remote access port
 
 
-def is_legacy_device(discovery: Optional[FluxLEDDiscovery]) -> bool:
+def is_legacy_device(discovery: FluxLEDDiscovery | None) -> bool:
     """Check if a discovery is a legacy device."""
     if not discovery:
         return False
@@ -192,16 +190,16 @@ class BulbScanner:
     def _create_socket(self) -> socket.socket:
         return create_udp_socket(self.DISCOVERY_PORT)
 
-    def _destination_from_address(self, address: Optional[str]) -> tuple[str, int]:
+    def _destination_from_address(self, address: str | None) -> tuple[str, int]:
         if address is None:
             address = self.BROADCAST_ADDRESS
         return (address, self.DISCOVERY_PORT)
 
     def _process_response(
         self,
-        data: Optional[bytes],
+        data: bytes | None,
         from_address: tuple[str, int],
-        address: Optional[str],
+        address: str | None,
         response_list: dict[str, FluxLEDDiscovery],
     ) -> bool:
         """Process a response.
@@ -282,7 +280,7 @@ class BulbScanner:
 
     def _send_message(
         self,
-        sender: Union[socket.socket, asyncio.DatagramTransport],
+        sender: socket.socket | asyncio.DatagramTransport,
         destination: tuple[str, int],
         message: bytes,
     ) -> None:
@@ -292,7 +290,7 @@ class BulbScanner:
     def _send_messages(
         self,
         messages: list[bytes],
-        sender: Union[socket.socket, asyncio.DatagramTransport],
+        sender: socket.socket | asyncio.DatagramTransport,
         destination: tuple[str, int],
     ) -> None:
         """Send messages with a short delay between them."""
@@ -307,7 +305,7 @@ class BulbScanner:
         return [self.DISCOVER_MESSAGE, self.VERSION_MESSAGE, self.REMOTE_ACCESS_MESSAGE]
 
     def scan(
-        self, timeout: int = 10, address: Optional[str] = None
+        self, timeout: int = 10, address: str | None = None
     ) -> list[FluxLEDDiscovery]:
         """Scan for bulbs.
 
@@ -343,7 +341,7 @@ class BulbScanner:
                 try:
                     data, addr = sock.recvfrom(self.RESPONSE_SIZE)
                     _LOGGER.debug("discover: %s <= %s", addr, data)
-                except socket.timeout:
+                except TimeoutError:
                     continue
 
                 if self._process_response(data, addr, address, self._discoveries):

--- a/flux_led/sock.py
+++ b/flux_led/sock.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from .const import DEFAULT_RETRIES
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 warn_unused_configs = true
 disable_error_code = no-redef
 exclude = dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 88
 
 [tool.ruff.lint]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ dev_requirements = [
 
 requirements = [
     "webcolors",
-    'typing_extensions;python_version<"3.8"',
     "async_timeout>=3.0.0",
 ]
 
@@ -70,9 +69,6 @@ setup(
         + "GNU Lesser General Public License v3 or later (LGPLv3+)",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -81,7 +77,7 @@ setup(
         "Topic :: Home Automation",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     setup_requires=setup_requirements,
     tests_require=test_requirements,
     extras_require=extra_requirements,

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -5,14 +5,8 @@ import contextlib
 import datetime
 import json
 import logging
-import sys
 import time
-from unittest.mock import MagicMock, call, patch
-
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    from unittest.mock import MagicMock as AsyncMock
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -2184,7 +2178,6 @@ async def test_0x06_rgbw_cct_cold(mock_aio_protocol, caplog: pytest.LogCaptureFi
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(sys.version_info[:3][1] == 7, reason="no AsyncMock in 3.7")
 async def test_wrapped_cct_protocol_device(mock_aio_protocol):
     """Test a wrapped cct protocol device."""
     light = AIOWifiLedBulb("192.168.1.166")
@@ -2314,7 +2307,6 @@ async def test_wrapped_cct_protocol_device(mock_aio_protocol):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(sys.version_info[:3][1] == 7, reason="no AsyncMock in 3.7")
 async def test_cct_protocol_device(mock_aio_protocol):
     """Test a original cct protocol device."""
     light = AIOWifiLedBulb("192.168.1.166")
@@ -3292,7 +3284,6 @@ async def test_async_config_remotes_unsupported_device(
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(sys.version_info[:3][1] == 7, reason="no AsyncMock in 3.7")
 async def test_async_config_remotes_no_response(
     mock_aio_protocol, caplog: pytest.LogCaptureFixture
 ):


### PR DESCRIPTION
Minimum Python is now 3.10; bumps all tooling, CI, and classifiers accordingly, and removes a few small legacy shims that targeted 3.7.