### PR TITLE
feat: add 0xB6 (AK001-ZJ21413 Surplife) reusing the 25-byte protocol

### DIFF
--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -732,7 +732,18 @@ class AIOWifiLedBulb(LEDENETDevice):
             self._process_state_futures()
         elif self._protocol.is_valid_extended_state_response(msg):
             self._last_message["extended_state"] = msg
+            # Devices like 0xB6 reply only with extended state, so the pending
+            # protocol determination must be resolved here too.
+            if (
+                self._determine_protocol_future
+                and not self._determine_protocol_future.done()
+            ):
+                self._set_protocol_from_msg(msg, self._protocol.name)
+                self._determine_protocol_future.set_result(True)
             self.process_extended_state_response(msg)
+            # Extended state carries both state and power information.
+            self._process_state_futures()
+            self._process_power_futures()
         elif self._protocol.is_valid_power_state_response(msg):
             self._last_message["power_state"] = msg
             self.process_power_state_response(msg)

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -1252,9 +1252,15 @@ class LEDENETDevice:
         full_msg: bytes,
         fallback_protocol: str,
     ) -> None:
-        self._model_num = full_msg[1]
+        if len(full_msg) >= 20 and full_msg[0] == 0xEA and full_msg[1] == 0x81:
+            # Extended state format (0xEA 0x81): model at byte 4, version at byte 5.
+            self._model_num = full_msg[4]
+            version_num = full_msg[5]
+        else:
+            # Standard state format (0x81): model at byte 1, version at byte 10.
+            self._model_num = full_msg[1]
+            version_num = full_msg[10] if len(full_msg) > 10 else 1
         self._model_data = get_model(self._model_num, fallback_protocol)
-        version_num = full_msg[10] if len(full_msg) > 10 else 1
         self.setProtocol(self._model_data.protocol_for_version_num(version_num))
 
     def _generate_preset_pattern(

--- a/flux_led/models_db.py
+++ b/flux_led/models_db.py
@@ -83,6 +83,7 @@ MODEL_INFO_NAMES = {
     "ZG-LX": "",  # Seen on floor lamp, v2 addressable, and Single channel controller
     "ZG-LX-UART": "",  # Seen on UK xmas lights 0x33, fairy controller, and lytworx
     "ZG-BL-PWM": "",  # Seen on 40w Flood Light
+    "ZG-BL-UFO": "",  # Seen on Surplife outdoor permanent lighting 0xB6
     "ZG-ZW2": "",  # seen on 0x97 socket
     "ZGIR44": "44 Key IR",
     "IR_ZG": "IR",
@@ -637,6 +638,15 @@ HARDWARE = [
         remote_24g_controls=False,
         auto_on=False,
         dimmable_effects=False,
+    ),
+    LEDENETHardware(
+        model="AK001-ZJ21413",  # Surplife outdoor permanent LED lighting
+        chip=LEDENETChip.BL602,
+        remote_rf=False,
+        remote_24g=True,  # has remote access enabled
+        remote_24g_controls=False,
+        auto_on=True,
+        dimmable_effects=True,
     ),
 ]
 
@@ -1295,6 +1305,23 @@ MODELS = [
         channel_map={},
         microphone=True,  # confirmed with mocks to be true
         device_config=NEW_ADDRESABLE_DEVICE_CONFIG,
+    ),
+    LEDENETModel(
+        model_num=0xB6,
+        models=["AK001-ZJ21413"],
+        description="Surplife Outdoor Permanent Lighting",
+        # This device ONLY responds with the extended state format (0xEA 0x81),
+        # which PROTOCOL_LEDENET_25BYTE already parses, so reusing it gives basic
+        # on/off, brightness and color. A dedicated protocol class with full
+        # custom-effect/timer support is added in a follow-up.
+        always_writes_white_and_colors=False,
+        protocols=[MinVersionProtocol(0, PROTOCOL_LEDENET_25BYTE)],
+        # Single white LED (not separate warm/cool), so use RGB_W not RGB_CCT
+        mode_to_color_mode={0x01: COLOR_MODES_RGB_W, 0x17: COLOR_MODES_RGB_W},
+        color_modes=COLOR_MODES_RGB_W,
+        channel_map={},
+        microphone=True,
+        device_config=IMMUTABLE_DEVICE_CONFIG,
     ),
     LEDENETModel(
         model_num=0xD1,

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -1021,6 +1021,14 @@ class ProtocolLEDENET8Byte(ProtocolBase):
         """Check if a message is the start of a state response."""
         return _message_type_from_start_of_msg(data) == MSG_POWER_STATE
 
+    def is_valid_extended_state_response(self, raw_state: bytes) -> bool:
+        """Check if this is an extended state response (0xEA 0x81 format).
+
+        The 0xB6 device replies only with this format, so probing must
+        recognise it to determine the protocol.
+        """
+        return len(raw_state) >= 20 and raw_state[0] == 0xEA and raw_state[1] == 0x81
+
     def is_valid_state_response(self, raw_state: bytes) -> bool:
         """Check if a state response is valid."""
         if len(raw_state) != self.state_response_length:

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -16,6 +16,7 @@ from flux_led.aioprotocol import AIOLEDENETProtocol
 from flux_led.aioscanner import AIOBulbScanner, LEDENETDiscovery
 from flux_led.const import (
     COLOR_MODE_CCT,
+    COLOR_MODE_DIM,
     COLOR_MODE_RGB,
     COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW,
@@ -4294,3 +4295,53 @@ async def test_setup_0x35_with_version_num_10(
         )
     )
     assert light.white_active is True
+
+
+@pytest.mark.asyncio
+async def test_setup_0xB6_surplife(mock_aio_protocol):
+    """0xB6 Surplife is recognised via the reused 25-byte protocol.
+
+    The device replies only with the extended state format (0xEA 0x81), so this
+    exercises protocol determination from an extended-only response (the case
+    that previously failed with "Cannot determine protocol").
+    """
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    _transport, _protocol = await mock_aio_protocol()
+    # Extended state: EA 81 01 00 B6(model) 01(ver) 23(on) 61 00 64 0F 00 00 00 64 64 00 00 00 00 CS
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x00,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+    assert light.model_num == 0xB6
+    assert light.protocol == PROTOCOL_LEDENET_25BYTE
+    assert light.color_modes == {COLOR_MODE_RGB, COLOR_MODE_DIM}
+    assert "Surplife" in light.model


### PR DESCRIPTION
Registers the Surplife outdoor light (model byte 0xB6) so basic functions (on/off, brightness, color) work by reusing PROTOCOL_LEDENET_25BYTE, which already parses the extended state format this device uses.

The device replies *only* with the extended state format (0xEA 0x81), so the minimal glue needed to recognize it is included:

- models_db.py: AK001-ZJ21413 hardware + 0xB6 model -> PROTOCOL_LEDENET_25BYTE
- protocol.py: ProtocolLEDENET8Byte.is_valid_extended_state_response so probing recognises the extended frame
- base_device.py: read model/version from the extended frame in _set_protocol_from_msg
- aiodevice.py: resolve protocol determination on the extended-state branch (previously only the standard branch resolved it, so an extended-only device timed out with 'Cannot determine protocol')

A dedicated protocol class, sync-path support and the custom-effect/timer features follow in follow-up PRs.