### PR TITLE
feat: dedicated ProtocolLEDENETExtendedCustom + LED count for 0xB6

### DIFF
--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -250,6 +250,7 @@ class LEDENETDevice:
         self._device_config: LEDENETAddressableDeviceConfiguration | None = None
         self._last_message: dict[str, bytes] = {}
         self._unavailable_reason: str | None = None
+        self._extended_led_count: int | None = None
 
     def _protocol_probes(
         self,
@@ -488,6 +489,11 @@ class LEDENETDevice:
         if self._device_config is None:
             return None
         return self._device_config.music_segments
+
+    @property
+    def led_count(self) -> int | None:
+        """Return the device's configured LED count (0xB6), or None if unknown."""
+        return self._extended_led_count
 
     @property
     def wiring(self) -> str | None:
@@ -868,6 +874,8 @@ class LEDENETDevice:
     def process_extended_state_response(self, msg: bytes) -> bool:
         """Process and extended state response."""
         assert self._protocol is not None
+        if isinstance(self._protocol, ProtocolLEDENETExtendedCustom):
+            self._extended_led_count = self._protocol.extended_state_led_count(msg)
         self._process_valid_state_response(self._protocol.extended_state_to_state(msg))
         return True
 

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -90,6 +90,7 @@ from .protocol import (
     PROTOCOL_LEDENET_ADDRESSABLE_CHRISTMAS,
     PROTOCOL_LEDENET_CCT,
     PROTOCOL_LEDENET_CCT_WRAPPED,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM,
     PROTOCOL_LEDENET_ORIGINAL,
     PROTOCOL_LEDENET_ORIGINAL_CCT,
     PROTOCOL_LEDENET_ORIGINAL_RGBW,
@@ -110,6 +111,7 @@ from .protocol import (
     ProtocolLEDENETAddressableChristmas,
     ProtocolLEDENETCCT,
     ProtocolLEDENETCCTWrapped,
+    ProtocolLEDENETExtendedCustom,
     ProtocolLEDENETOriginal,
     ProtocolLEDENETOriginalCCT,
     ProtocolLEDENETOriginalRGBW,
@@ -143,6 +145,7 @@ PROTOCOL_TYPES = (
     | ProtocolLEDENET9ByteAutoOn
     | ProtocolLEDENET9ByteDimmableEffects
     | ProtocolLEDENET25Byte
+    | ProtocolLEDENETExtendedCustom
     | ProtocolLEDENETAddressableA1
     | ProtocolLEDENETAddressableA2
     | ProtocolLEDENETAddressableA3
@@ -187,6 +190,7 @@ PROTOCOL_NAME_TO_CLS = {
     PROTOCOL_LEDENET_9BYTE_AUTO_ON: ProtocolLEDENET9ByteAutoOn,
     PROTOCOL_LEDENET_9BYTE_DIMMABLE_EFFECTS: ProtocolLEDENET9ByteDimmableEffects,
     PROTOCOL_LEDENET_25BYTE: ProtocolLEDENET25Byte,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM: ProtocolLEDENETExtendedCustom,
     PROTOCOL_LEDENET_ADDRESSABLE_A3: ProtocolLEDENETAddressableA3,
     PROTOCOL_LEDENET_ADDRESSABLE_A2: ProtocolLEDENETAddressableA2,
     PROTOCOL_LEDENET_ADDRESSABLE_A1: ProtocolLEDENETAddressableA1,
@@ -637,6 +641,11 @@ class LEDENETDevice:
         if self.microphone:
             return [*effects, EFFECT_RANDOM, EFFECT_MUSIC]
         return [*effects, EFFECT_RANDOM]
+
+    @property
+    def supports_extended_custom_effects(self) -> bool:
+        """Return True if the device uses the extended custom protocol."""
+        return self.protocol == PROTOCOL_LEDENET_EXTENDED_CUSTOM
 
     @property
     def effect(self) -> str | None:

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -802,6 +802,12 @@ class LEDENETDevice:
                 utils.raw_state_to_dec(rx),
             )
             return False
+        # The sync path delivers the raw extended frame here (0xB6 only ever
+        # replies with the extended state), so capture the LED count before the
+        # frame is converted to the standard layout. The async path stores it in
+        # process_extended_state_response instead.
+        if isinstance(self._protocol, ProtocolLEDENETExtendedCustom):
+            self._extended_led_count = self._protocol.extended_state_led_count(rx)
         return self._process_valid_state_response(rx)
 
     def _process_valid_state_response(self, rx: bytes | bytearray) -> bool:

--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -276,8 +276,17 @@ class WifiLedBulb(LEDENETDevice):
                 # cannot process, recycle the connection
                 self.close()
                 continue
-            full_msg = rx + self._read_msg(protocol.state_response_length - read_bytes)
-            if not protocol.is_valid_state_response(full_msg):
+            # Extended-state-only devices (e.g. 0xB6) reply with 0xEA 0x81 and
+            # need 21 bytes total instead of the standard state length.
+            if rx[0] == 0xEA and rx[1] == 0x81:
+                additional_bytes = 19  # 21 - 2 bytes already read
+            else:
+                additional_bytes = protocol.state_response_length - read_bytes
+            full_msg = rx + self._read_msg(additional_bytes)
+            if not (
+                protocol.is_valid_state_response(full_msg)
+                or protocol.is_valid_extended_state_response(full_msg)
+            ):
                 self.close()
                 continue
             assert isinstance(full_msg, bytearray)

--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -281,7 +281,7 @@ class WifiLedBulb(LEDENETDevice):
                 self.close()
                 continue
             # Extended-state-only devices (e.g. 0xB6) reply with 0xEA 0x81 and
-            # need 21 bytes total instead of the standard state length.
+            # need 27 bytes total instead of the standard state length.
             if rx[0] == 0xEA and rx[1] == 0x81:
                 additional_bytes = LEDENET_EXTENDED_STATE_RESPONSE_LEN - read_bytes
             else:

--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -7,7 +7,11 @@ import socket
 import threading
 import time
 
-from flux_led.protocol import LEDENET_TIME_RESPONSE_LEN, ProtocolLEDENETOriginal
+from flux_led.protocol import (
+    LEDENET_EXTENDED_STATE_RESPONSE_LEN,
+    LEDENET_TIME_RESPONSE_LEN,
+    ProtocolLEDENETOriginal,
+)
 
 from .base_device import LEDENETDevice
 from .const import (
@@ -279,7 +283,7 @@ class WifiLedBulb(LEDENETDevice):
             # Extended-state-only devices (e.g. 0xB6) reply with 0xEA 0x81 and
             # need 21 bytes total instead of the standard state length.
             if rx[0] == 0xEA and rx[1] == 0x81:
-                additional_bytes = 19  # 21 - 2 bytes already read
+                additional_bytes = LEDENET_EXTENDED_STATE_RESPONSE_LEN - read_bytes
             else:
                 additional_bytes = protocol.state_response_length - read_bytes
             full_msg = rx + self._read_msg(additional_bytes)

--- a/flux_led/models_db.py
+++ b/flux_led/models_db.py
@@ -47,6 +47,7 @@ from .protocol import (
     PROTOCOL_LEDENET_ADDRESSABLE_CHRISTMAS,
     PROTOCOL_LEDENET_CCT,
     PROTOCOL_LEDENET_CCT_WRAPPED,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM,
     PROTOCOL_LEDENET_ORIGINAL,
     PROTOCOL_LEDENET_ORIGINAL_CCT,
     PROTOCOL_LEDENET_SOCKET,
@@ -1310,12 +1311,11 @@ MODELS = [
         model_num=0xB6,
         models=["AK001-ZJ21413"],
         description="Surplife Outdoor Permanent Lighting",
-        # This device ONLY responds with the extended state format (0xEA 0x81),
-        # which PROTOCOL_LEDENET_25BYTE already parses, so reusing it gives basic
-        # on/off, brightness and color. A dedicated protocol class with full
-        # custom-effect/timer support is added in a follow-up.
+        # This device ONLY responds with the extended state format (0xEA 0x81).
+        # It uses the dedicated ProtocolLEDENETExtendedCustom protocol, which adds
+        # the custom-effect, segment-color and timer support specific to it.
         always_writes_white_and_colors=False,
-        protocols=[MinVersionProtocol(0, PROTOCOL_LEDENET_25BYTE)],
+        protocols=[MinVersionProtocol(0, PROTOCOL_LEDENET_EXTENDED_CUSTOM)],
         # Single white LED (not separate warm/cool), so use RGB_W not RGB_CCT
         mode_to_color_mode={0x01: COLOR_MODES_RGB_W, 0x17: COLOR_MODES_RGB_W},
         color_modes=COLOR_MODES_RGB_W,

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -97,6 +97,7 @@ PROTOCOL_LEDENET_CCT = "LEDENET_CCT"
 PROTOCOL_LEDENET_CCT_WRAPPED = "LEDENET_CCT_WRAPPED"
 PROTOCOL_LEDENET_ADDRESSABLE_CHRISTMAS = "LEDENET_CHRISTMAS"
 PROTOCOL_LEDENET_25BYTE = "LEDENET_25_BYTE"
+PROTOCOL_LEDENET_EXTENDED_CUSTOM = "LEDENET_EXTENDED_CUSTOM"
 
 TRANSITION_BYTES = {
     TRANSITION_JUMP: 0x3B,
@@ -109,6 +110,7 @@ LEDNET_MUSIC_MODE_RESPONSE_LEN = 13  # 72 01 26 01 00 00 00 00 00 00 64 64 62
 LEDENET_POWER_RESTORE_RESPONSE_LEN = 7
 LEDENET_ORIGINAL_STATE_RESPONSE_LEN = 11
 LEDENET_STATE_RESPONSE_LEN = 14
+LEDENET_EXTENDED_STATE_RESPONSE_LEN = 21
 LEDENET_POWER_RESPONSE_LEN = 4
 LEDENET_ADDRESSABLE_STATE_RESPONSE_LEN = 25
 LEDENET_A1_DEVICE_CONFIG_RESPONSE_LEN = 12
@@ -1599,6 +1601,107 @@ class ProtocolLEDENET25Byte(ProtocolLEDENET9Byte):
                 version=0x02,
             )
         ]
+
+
+class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
+    """Protocol for the 0xB6 Surplife device (extended state + custom effects).
+
+    This device only ever responds with the extended state format (0xEA 0x81)
+    and uses an HSV+W color format. It reuses ProtocolLEDENET25Byte for the
+    standard command set; dedicated custom-effect and timer support is added in
+    follow-up changes.
+    """
+
+    @property
+    def name(self) -> str:
+        """The name of the protocol."""
+        return PROTOCOL_LEDENET_EXTENDED_CUSTOM
+
+    @property
+    def state_response_length(self) -> int:
+        """The length of the query response (extended state, 21 bytes)."""
+        return LEDENET_EXTENDED_STATE_RESPONSE_LEN
+
+    def is_valid_state_response(self, raw_state: bytes) -> bool:
+        """Check if a state response is valid.
+
+        This protocol ONLY accepts the extended state format (0xEA 0x81).
+        """
+        return self.is_valid_extended_state_response(raw_state)
+
+    def named_raw_state(self, raw_state: bytes) -> LEDENETRawState:
+        """Convert raw_state to a namedtuple.
+
+        The extended state format (0xEA 0x81) is converted to the standard
+        14-byte layout first so the synchronous state path can parse it.
+        """
+        if self.is_valid_extended_state_response(raw_state):
+            raw_state = self.extended_state_to_state(raw_state)
+        return LEDENETRawState(*raw_state)
+
+    def extended_state_to_state(self, raw_state: bytes) -> bytes:
+        """Convert extended state to standard state format.
+
+        For this protocol, the extended state mode (position 8) always contains
+        the custom effect pattern ID when preset_pattern is 0x25, and a white
+        brightness of 0 (or out-of-range temp) means the white LED is off.
+        """
+        if len(raw_state) < 20:
+            return b""
+
+        model_num = raw_state[4]
+        version_number = raw_state[5]
+        power_state = raw_state[6]
+        preset_pattern = raw_state[7]
+        speed = raw_state[9]
+
+        hue = raw_state[11]
+        saturation = raw_state[12]
+        value = raw_state[13]
+
+        white_temp = raw_state[14]
+        white_brightness = raw_state[15]
+
+        if white_temp > 100 or white_brightness == 0:
+            cool_white = 0
+            warm_white = 0
+        else:
+            levels = scaled_color_temp_to_white_levels(white_temp, white_brightness)
+            cool_white = levels.cool_white
+            warm_white = levels.warm_white
+
+        # Convert HSV to RGB
+        h = (hue * 2) / 360
+        s = saturation / 100
+        v = value / 100
+        r_f, g_f, b_f = colorsys.hsv_to_rgb(h, s, v)
+        red = min(int(max(0, r_f) * 255), 255)
+        green = min(int(max(0, g_f) * 255), 255)
+        blue = min(int(max(0, b_f) * 255), 255)
+
+        # mode carries the effect pattern ID in custom pattern mode (0x25)
+        mode = raw_state[8] if preset_pattern == 0x25 else 0
+        color_mode = 0
+        check_sum = 0
+
+        return bytes(
+            (
+                raw_state[1],  # Head (0x81)
+                model_num,
+                power_state,
+                preset_pattern,
+                mode,
+                speed,
+                red,
+                green,
+                blue,
+                warm_white,
+                version_number,
+                cool_white,
+                color_mode,
+                check_sum,
+            )
+        )
 
 
 class ProtocolLEDENETAddressableBase(ProtocolLEDENET9Byte):

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -1663,7 +1663,7 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
         white_temp = raw_state[14]
         white_brightness = raw_state[15]
 
-        if white_temp > 100 or white_brightness == 0:
+        if white_temp > 100 or white_brightness == 0 or white_brightness > 100:
             cool_white = 0
             warm_white = 0
         else:
@@ -1704,7 +1704,7 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
             )
         )
 
-    def extended_state_led_count(self, raw_state: bytes) -> int | None:
+    def extended_state_led_count(self, raw_state: bytes | bytearray) -> int | None:
         """Return the configured LED count from an extended state response, or None."""
         if not self.is_valid_extended_state_response(raw_state):
             return None

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -120,6 +120,7 @@ LEDENET_TIME_RESPONSE_LEN = 12  # 10 14 16 01 02 10 26 20 07 00 0f a9
 LEDENET_TIMERS_8BYTE_RESPONSE_LEN = 88
 LEDENET_TIMERS_9BYTE_RESPONSE_LEN = 94
 LEDENET_TIMERS_SOCKET_RESPONSE_LEN = 100
+LEDENET_EXTENDED_STATE_LED_COUNT_POS = 18  # byte index in the raw extended state buffer
 
 MSG_ORIGINAL_POWER_STATE = "original_power_state"
 MSG_ORIGINAL_STATE = "original_state"
@@ -508,11 +509,11 @@ class ProtocolBase:
     def is_valid_state_response(self, raw_state: bytes | bytearray) -> bool:
         """Check if a state response is valid."""
 
-    def is_valid_extended_state_response(self, raw_state: bytes) -> bool:
+    def is_valid_extended_state_response(self, raw_state: bytes | bytearray) -> bool:
         return False
 
     @abstractmethod
-    def extended_state_to_state(self, raw_state: bytes) -> bytes:
+    def extended_state_to_state(self, raw_state: bytes | bytearray) -> bytes:
         """Convert an extended state response to a state response."""
 
     def is_checksum_correct(self, msg: bytes | bytearray) -> bool:
@@ -1023,7 +1024,7 @@ class ProtocolLEDENET8Byte(ProtocolBase):
         """Check if a message is the start of a state response."""
         return _message_type_from_start_of_msg(data) == MSG_POWER_STATE
 
-    def is_valid_extended_state_response(self, raw_state: bytes) -> bool:
+    def is_valid_extended_state_response(self, raw_state: bytes | bytearray) -> bool:
         """Check if this is an extended state response (0xEA 0x81 format).
 
         The 0xB6 device replies only with this format, so probing must
@@ -1444,11 +1445,11 @@ class ProtocolLEDENET25Byte(ProtocolLEDENET9Byte):
         """The name of the protocol."""
         return PROTOCOL_LEDENET_25BYTE
 
-    def is_valid_extended_state_response(self, raw_state: bytes) -> bool:
+    def is_valid_extended_state_response(self, raw_state: bytes | bytearray) -> bool:
         """Check if a state response is valid."""
         return raw_state[0] == 0xEA and raw_state[1] == 0x81 and len(raw_state) >= 20
 
-    def extended_state_to_state(self, raw_state: bytes) -> bytes:
+    def extended_state_to_state(self, raw_state: bytes | bytearray) -> bytes:
         """Convert an extended state response to a state response."""
         # pos  0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19
         #     EA  81  01  10  35  0A  23  61  01  50  0F  3C  64  64  00  64  00  00  00  00
@@ -1622,14 +1623,14 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
         """The length of the query response (extended state, 21 bytes)."""
         return LEDENET_EXTENDED_STATE_RESPONSE_LEN
 
-    def is_valid_state_response(self, raw_state: bytes) -> bool:
+    def is_valid_state_response(self, raw_state: bytes | bytearray) -> bool:
         """Check if a state response is valid.
 
         This protocol ONLY accepts the extended state format (0xEA 0x81).
         """
         return self.is_valid_extended_state_response(raw_state)
 
-    def named_raw_state(self, raw_state: bytes) -> LEDENETRawState:
+    def named_raw_state(self, raw_state: bytes | bytearray) -> LEDENETRawState:
         """Convert raw_state to a namedtuple.
 
         The extended state format (0xEA 0x81) is converted to the standard
@@ -1639,7 +1640,7 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
             raw_state = self.extended_state_to_state(raw_state)
         return LEDENETRawState(*raw_state)
 
-    def extended_state_to_state(self, raw_state: bytes) -> bytes:
+    def extended_state_to_state(self, raw_state: bytes | bytearray) -> bytes:
         """Convert extended state to standard state format.
 
         For this protocol, the extended state mode (position 8) always contains
@@ -1702,6 +1703,12 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
                 check_sum,
             )
         )
+
+    def extended_state_led_count(self, raw_state: bytes) -> int | None:
+        """Return the configured LED count from an extended state response, or None."""
+        if not self.is_valid_extended_state_response(raw_state):
+            return None
+        return raw_state[LEDENET_EXTENDED_STATE_LED_COUNT_POS]
 
 
 class ProtocolLEDENETAddressableBase(ProtocolLEDENET9Byte):

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -1470,14 +1470,31 @@ class ProtocolLEDENET25Byte(ProtocolLEDENET9Byte):
         #      |   |   |   |   |   |   Power state (0x23 = ON, 0x24 = OFF)
         #      |   |   |   |   |   ??
         #      |   |   |   |   Version number
-        #      |   |   |   Model number
+        #      |   |   |   Model number (0x25 = pattern ID, otherwise 0)
         #      |   |   Unknown / reserved
         #      |   Unknown / reserved
         #   Extended message header (ea 81)
 
         if len(raw_state) < 20:
             return b""
+        levels = scaled_color_temp_to_white_levels(raw_state[14], raw_state[15])
+        return self._extended_state_to_state(
+            raw_state, levels.cool_white, levels.warm_white, mode=0
+        )
 
+    def _extended_state_to_state(
+        self,
+        raw_state: bytes | bytearray,
+        cool_white: int,
+        warm_white: int,
+        mode: int,
+    ) -> bytes:
+        """Assemble a standard state response from an extended state response.
+
+        Shared by ProtocolLEDENET25Byte and its subclasses; callers supply the
+        white levels and ``mode`` byte (the parts that vary per protocol) so the
+        byte unpacking and HSV->RGB conversion live in one place.
+        """
         model_num = raw_state[4]
         version_number = raw_state[5]
         power_state = raw_state[6]
@@ -1488,13 +1505,6 @@ class ProtocolLEDENET25Byte(ProtocolLEDENET9Byte):
         saturation = raw_state[12]
         value = raw_state[13]
 
-        white_temp = raw_state[14]
-        white_brightness = raw_state[15]
-        levels = scaled_color_temp_to_white_levels(white_temp, white_brightness)
-
-        cool_white = levels.cool_white
-        warm_white = levels.warm_white
-
         # Convert HSV to RGB
         h = (hue * 2) / 360
         s = saturation / 100
@@ -1504,8 +1514,6 @@ class ProtocolLEDENET25Byte(ProtocolLEDENET9Byte):
         green = min(int(max(0, g_f) * 255), 255)
         blue = min(int(max(0, b_f) * 255), 255)
 
-        # Fill standard state structure
-        mode = 0
         color_mode = 0
         check_sum = 0  # Set to 0; not critical
 
@@ -1643,26 +1651,18 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
     def extended_state_to_state(self, raw_state: bytes | bytearray) -> bytes:
         """Convert extended state to standard state format.
 
-        For this protocol, the extended state mode (position 8) always contains
-        the custom effect pattern ID when preset_pattern is 0x25, and a white
-        brightness of 0 (or out-of-range temp) means the white LED is off.
+        Computes the 0xB6-specific white levels and ``mode`` byte, then defers
+        to the shared ``_extended_state_to_state`` helper for the HSV->RGB
+        conversion and assembly. A white brightness of 0 (or out-of-range
+        temp/brightness) means the white LED is off; the guard also avoids
+        passing out-of-range values to ``scaled_color_temp_to_white_levels``.
+        ``mode`` carries the custom effect pattern ID when preset_pattern is
+        0x25.
         """
         if len(raw_state) < 20:
             return b""
-
-        model_num = raw_state[4]
-        version_number = raw_state[5]
-        power_state = raw_state[6]
-        preset_pattern = raw_state[7]
-        speed = raw_state[9]
-
-        hue = raw_state[11]
-        saturation = raw_state[12]
-        value = raw_state[13]
-
         white_temp = raw_state[14]
         white_brightness = raw_state[15]
-
         if white_temp > 100 or white_brightness == 0 or white_brightness > 100:
             cool_white = 0
             warm_white = 0
@@ -1670,39 +1670,9 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
             levels = scaled_color_temp_to_white_levels(white_temp, white_brightness)
             cool_white = levels.cool_white
             warm_white = levels.warm_white
-
-        # Convert HSV to RGB
-        h = (hue * 2) / 360
-        s = saturation / 100
-        v = value / 100
-        r_f, g_f, b_f = colorsys.hsv_to_rgb(h, s, v)
-        red = min(int(max(0, r_f) * 255), 255)
-        green = min(int(max(0, g_f) * 255), 255)
-        blue = min(int(max(0, b_f) * 255), 255)
-
         # mode carries the effect pattern ID in custom pattern mode (0x25)
-        mode = raw_state[8] if preset_pattern == 0x25 else 0
-        color_mode = 0
-        check_sum = 0
-
-        return bytes(
-            (
-                raw_state[1],  # Head (0x81)
-                model_num,
-                power_state,
-                preset_pattern,
-                mode,
-                speed,
-                red,
-                green,
-                blue,
-                warm_white,
-                version_number,
-                cool_white,
-                color_mode,
-                check_sum,
-            )
-        )
+        mode = raw_state[8] if raw_state[7] == 0x25 else 0
+        return self._extended_state_to_state(raw_state, cool_white, warm_white, mode)
 
     def extended_state_led_count(self, raw_state: bytes | bytearray) -> int | None:
         """Return the configured LED count from an extended state response, or None."""

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -110,7 +110,7 @@ LEDNET_MUSIC_MODE_RESPONSE_LEN = 13  # 72 01 26 01 00 00 00 00 00 00 64 64 62
 LEDENET_POWER_RESTORE_RESPONSE_LEN = 7
 LEDENET_ORIGINAL_STATE_RESPONSE_LEN = 11
 LEDENET_STATE_RESPONSE_LEN = 14
-LEDENET_EXTENDED_STATE_RESPONSE_LEN = 21
+LEDENET_EXTENDED_STATE_RESPONSE_LEN = 27
 LEDENET_POWER_RESPONSE_LEN = 4
 LEDENET_ADDRESSABLE_STATE_RESPONSE_LEN = 25
 LEDENET_A1_DEVICE_CONFIG_RESPONSE_LEN = 12
@@ -1620,7 +1620,7 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
 
     @property
     def state_response_length(self) -> int:
-        """The length of the query response (extended state, 21 bytes)."""
+        """The length of the query response (extended state, 27 bytes)."""
         return LEDENET_EXTENDED_STATE_RESPONSE_LEN
 
     def is_valid_state_response(self, raw_state: bytes | bytearray) -> bool:

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -28,18 +28,22 @@ from flux_led.const import (
     WhiteChannelType,
 )
 from flux_led.protocol import (
+    LEDENET_EXTENDED_STATE_RESPONSE_LEN,
     PROTOCOL_LEDENET_8BYTE_AUTO_ON,
     PROTOCOL_LEDENET_8BYTE_DIMMABLE_EFFECTS,
     PROTOCOL_LEDENET_9BYTE,
     PROTOCOL_LEDENET_25BYTE,
     PROTOCOL_LEDENET_ADDRESSABLE_CHRISTMAS,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM,
     PROTOCOL_LEDENET_ORIGINAL,
     LEDENETRawState,
     PowerRestoreState,
     PowerRestoreStates,
+    ProtocolLEDENET8Byte,
     ProtocolLEDENET25Byte,
     ProtocolLEDENETCCT,
     ProtocolLEDENETCCTWrapped,
+    ProtocolLEDENETExtendedCustom,
     RemoteConfig,
 )
 from flux_led.scanner import (
@@ -4342,6 +4346,49 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
     )
     await task
     assert light.model_num == 0xB6
-    assert light.protocol == PROTOCOL_LEDENET_25BYTE
+    assert light.protocol == PROTOCOL_LEDENET_EXTENDED_CUSTOM
     assert light.color_modes == {COLOR_MODE_RGB, COLOR_MODE_DIM}
     assert "Surplife" in light.model
+    assert light.supports_extended_custom_effects is True
+
+
+def test_protocol_extended_custom_state_response_length():
+    """ProtocolLEDENETExtendedCustom expects the 21-byte extended state."""
+    proto = ProtocolLEDENETExtendedCustom()
+    assert proto.state_response_length == LEDENET_EXTENDED_STATE_RESPONSE_LEN
+
+
+def test_protocol_extended_state_validation_0xB6():
+    """The protocols recognise the extended (0xEA 0x81) state response."""
+    ext = bytes(
+        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
+        + (0x00, 0x00, 0x00, 0x64, 0x64, 0x00, 0x00, 0x00, 0x00, 0x83)
+    )
+    # ProtocolLEDENET8Byte (used while probing) recognises the extended frame.
+    assert ProtocolLEDENET8Byte().is_valid_extended_state_response(ext) is True
+    # The dedicated protocol only accepts the extended format.
+    proto = ProtocolLEDENETExtendedCustom()
+    assert proto.is_valid_state_response(ext) is True
+    assert proto.is_valid_state_response(bytes((0x81,)) + b"\x00" * 13) is False
+
+
+def test_protocol_extended_state_to_state_white_off():
+    """white_brightness of 0 maps to both white channels off."""
+    ext = bytes(
+        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
+        + (0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x83)
+    )
+    result = ProtocolLEDENETExtendedCustom().extended_state_to_state(ext)
+    assert result[9] == 0  # warm_white
+    assert result[11] == 0  # cool_white
+
+
+def test_protocol_named_raw_state_extended_conversion():
+    """named_raw_state converts an extended frame to the standard layout."""
+    ext = bytes(
+        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
+        + (0x00, 0x00, 0x00, 0x64, 0x64, 0x00, 0x00, 0x00, 0x00, 0x83)
+    )
+    result = ProtocolLEDENETExtendedCustom().named_raw_state(ext)
+    assert result.head == 0x81
+    assert result.model_num == 0xB6

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -4316,7 +4316,8 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
 
     task = asyncio.create_task(light.async_setup(_updated_callback))
     _transport, _protocol = await mock_aio_protocol()
-    # Extended state: EA 81 01 00 B6(model) 01(ver) 23(on) 61 00 64 0F 00 00 00 64 64 00 00 64(count) 00 CS
+    # Real captured 27-byte extended state frame; byte 18 = 0x64 (LED count 100):
+    # EA 81 01 00 B6(model) 09 24 66 01 64 F0 00 00 00 00 64 05 00 64(count) 00 00 00 20 02 01 00 03
     light._aio_protocol.data_received(
         bytes(
             (
@@ -4325,22 +4326,28 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
                 0x01,
                 0x00,
                 0xB6,
+                0x09,
+                0x24,
+                0x66,
                 0x01,
-                0x23,
-                0x61,
-                0x00,
                 0x64,
-                0x0F,
+                0xF0,
+                0x00,
                 0x00,
                 0x00,
                 0x00,
                 0x64,
+                0x05,
+                0x00,
                 0x64,
                 0x00,
                 0x00,
-                0x64,
                 0x00,
-                0x83,
+                0x20,
+                0x02,
+                0x01,
+                0x00,
+                0x03,
             )
         )
     )

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -4360,10 +4360,7 @@ def test_protocol_extended_custom_state_response_length():
 
 def test_protocol_extended_state_validation_0xB6():
     """The protocols recognise the extended (0xEA 0x81) state response."""
-    ext = bytes(
-        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
-        + (0x00, 0x00, 0x00, 0x64, 0x64, 0x00, 0x00, 0x00, 0x00, 0x83)
-    )
+    ext = bytes.fromhex("ea810100b605236100640f00000064640000000083")
     # ProtocolLEDENET8Byte (used while probing) recognises the extended frame.
     assert ProtocolLEDENET8Byte().is_valid_extended_state_response(ext) is True
     # The dedicated protocol only accepts the extended format.
@@ -4374,21 +4371,43 @@ def test_protocol_extended_state_validation_0xB6():
 
 def test_protocol_extended_state_to_state_white_off():
     """white_brightness of 0 maps to both white channels off."""
-    ext = bytes(
-        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
-        + (0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x83)
-    )
+    ext = bytes.fromhex("ea810100b605236100640f000000ff000000000083")
     result = ProtocolLEDENETExtendedCustom().extended_state_to_state(ext)
     assert result[9] == 0  # warm_white
     assert result[11] == 0  # cool_white
 
 
+def test_protocol_extended_state_to_state_too_short_returns_empty():
+    """A truncated extended frame (< 20 bytes) returns an empty bytestring."""
+    proto = ProtocolLEDENETExtendedCustom()
+    assert proto.extended_state_to_state(b"\xea\x81\x01\x00\xb6") == b""
+
+
 def test_protocol_named_raw_state_extended_conversion():
     """named_raw_state converts an extended frame to the standard layout."""
-    ext = bytes(
-        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
-        + (0x00, 0x00, 0x00, 0x64, 0x64, 0x00, 0x00, 0x00, 0x00, 0x83)
-    )
+    ext = bytes.fromhex("ea810100b605236100640f00000064640000000083")
     result = ProtocolLEDENETExtendedCustom().named_raw_state(ext)
     assert result.head == 0x81
     assert result.model_num == 0xB6
+
+
+def test_extended_state_led_count():
+    """extended_state_led_count returns the configured LED count from real captured frames.
+
+    Real captured frames (0xB6 device):
+      LED count = 100: ea 81 01 00 b6 09 24 66 01 64 f0 00 00 00 00 64 05 00 64 00 00 00 20 02 01 00 03
+      LED count =  80: ea 81 01 00 b6 09 23 66 01 64 f0 00 00 00 00 64 05 00 50 00 00 00 20 02 01 00 03
+
+    The LED count byte is at index 18 of the raw extended state buffer.
+    """
+    proto = ProtocolLEDENETExtendedCustom()
+
+    frame_100 = bytes.fromhex("ea810100b60924660164f000000000640500640000002002010003")
+    frame_80 = bytes.fromhex("ea810100b60923660164f000000000640500500000002002010003")
+
+    assert proto.extended_state_led_count(frame_100) == 100
+    assert proto.extended_state_led_count(frame_80) == 80
+
+    # Too-short / invalid frame returns None
+    assert proto.extended_state_led_count(b"\xea\x81\x01") is None
+    assert proto.extended_state_led_count(b"\x00" * 27) is None

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -4316,7 +4316,7 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
 
     task = asyncio.create_task(light.async_setup(_updated_callback))
     _transport, _protocol = await mock_aio_protocol()
-    # Extended state: EA 81 01 00 B6(model) 01(ver) 23(on) 61 00 64 0F 00 00 00 64 64 00 00 00 00 CS
+    # Extended state: EA 81 01 00 B6(model) 01(ver) 23(on) 61 00 64 0F 00 00 00 64 64 00 00 64(count) 00 CS
     light._aio_protocol.data_received(
         bytes(
             (
@@ -4338,7 +4338,7 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
                 0x64,
                 0x00,
                 0x00,
-                0x00,
+                0x64,
                 0x00,
                 0x83,
             )
@@ -4350,6 +4350,9 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
     assert light.color_modes == {COLOR_MODE_RGB, COLOR_MODE_DIM}
     assert "Surplife" in light.model
     assert light.supports_extended_custom_effects is True
+    # The configured LED count (extended-state byte 18 = 0x64) is exposed
+    # end-to-end via the device property (async path store).
+    assert light.led_count == 100
 
 
 def test_protocol_extended_custom_state_response_length():
@@ -4372,6 +4375,19 @@ def test_protocol_extended_state_validation_0xB6():
 def test_protocol_extended_state_to_state_white_off():
     """white_brightness of 0 maps to both white channels off."""
     ext = bytes.fromhex("ea810100b605236100640f000000ff000000000083")
+    result = ProtocolLEDENETExtendedCustom().extended_state_to_state(ext)
+    assert result[9] == 0  # warm_white
+    assert result[11] == 0  # cool_white
+
+
+def test_protocol_extended_state_to_state_white_brightness_out_of_range():
+    """white_brightness > 100 maps to both white channels off (no ValueError).
+
+    Byte 15 is a raw 0-255 value; an out-of-range white brightness must not
+    crash ``scaled_color_temp_to_white_levels`` (which rejects brightness > 100).
+    Temp (byte 14 = 0x32) is in range so only the brightness guard applies.
+    """
+    ext = bytes.fromhex("ea810100b605236100640f00000032c80000000083")
     result = ProtocolLEDENETExtendedCustom().extended_state_to_state(ext)
     assert result[9] == 0  # warm_white
     assert result[11] == 0  # cool_white

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -4316,8 +4316,7 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
 
     task = asyncio.create_task(light.async_setup(_updated_callback))
     _transport, _protocol = await mock_aio_protocol()
-    # Real captured 27-byte extended state frame; byte 18 = 0x64 (LED count 100):
-    # EA 81 01 00 B6(model) 09 24 66 01 64 F0 00 00 00 00 64 05 00 64(count) 00 00 00 20 02 01 00 03
+    # Extended state: EA 81 01 00 B6(model) 01(ver) 23(on) 61 00 64 0F 00 00 00 64 64 00 00 64(count) 00 CS
     light._aio_protocol.data_received(
         bytes(
             (
@@ -4326,28 +4325,22 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
                 0x01,
                 0x00,
                 0xB6,
-                0x09,
-                0x24,
-                0x66,
                 0x01,
-                0x64,
-                0xF0,
-                0x00,
-                0x00,
-                0x00,
+                0x23,
+                0x61,
                 0x00,
                 0x64,
-                0x05,
+                0x0F,
                 0x00,
+                0x00,
+                0x00,
+                0x64,
                 0x64,
                 0x00,
                 0x00,
+                0x64,
                 0x00,
-                0x20,
-                0x02,
-                0x01,
-                0x00,
-                0x03,
+                0x83,
             )
         )
     )
@@ -4362,8 +4355,36 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
     assert light.led_count == 100
 
 
+@pytest.mark.asyncio
+async def test_setup_0xB6_surplife_real_frame(mock_aio_protocol):
+    """0xB6 setup against the real 27-byte capture from the device.
+
+    Unlike test_setup_0xB6_surplife (a minimal synthetic frame), this feeds the
+    actual 27-byte frame captured from hardware so extended_state_to_state runs
+    against real wire data (byte 7 = 0x66, byte 8 = 0x01, byte 18 = LED count).
+    """
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    _transport, _protocol = await mock_aio_protocol()
+    # EA 81 01 00 B6(model) 09 24 66 01 64 F0 00 00 00 00 64 05 00 64(count) 00 00 00 20 02 01 00 03
+    light._aio_protocol.data_received(
+        bytes.fromhex("ea810100b60924660164f00000000064050064000000200201000003")
+    )
+    await task
+    assert light.model_num == 0xB6
+    assert light.protocol == PROTOCOL_LEDENET_EXTENDED_CUSTOM
+    assert "Surplife" in light.model
+    assert light.supports_extended_custom_effects is True
+    # Configured LED count from extended-state byte 18 (0x64 = 100).
+    assert light.led_count == 100
+
+
 def test_protocol_extended_custom_state_response_length():
-    """ProtocolLEDENETExtendedCustom expects the 21-byte extended state."""
+    """ProtocolLEDENETExtendedCustom expects the 27-byte extended state."""
     proto = ProtocolLEDENETExtendedCustom()
     assert proto.state_response_length == LEDENET_EXTENDED_STATE_RESPONSE_LEN
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -33,6 +33,7 @@ from flux_led.protocol import (
     PROTOCOL_LEDENET_ADDRESSABLE_A1,
     PROTOCOL_LEDENET_ADDRESSABLE_A2,
     PROTOCOL_LEDENET_ADDRESSABLE_A3,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM,
     PROTOCOL_LEDENET_ORIGINAL,
     PROTOCOL_LEDENET_ORIGINAL_CCT,
     PROTOCOL_LEDENET_SOCKET,
@@ -1421,6 +1422,43 @@ class TestLight(unittest.TestCase):
 
         light.set_effect("colorloop", 50, 50)
         self.assertEqual(mock_send.call_args, mock.call(bytearray(b"8%\x102\x9f")))
+
+    @patch("flux_led.WifiLedBulb._send_msg")
+    @patch("flux_led.WifiLedBulb._read_msg")
+    @patch("flux_led.WifiLedBulb.connect")
+    def test_0xB6_surplife_sync(self, mock_connect, mock_read, mock_send):
+        """0xB6 Surplife works via the dedicated protocol (sync API)."""
+        calls = 0
+
+        def read_data(expected):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                self.assertEqual(expected, 2)
+                # 0xB6 device returns extended state format (0xEA 0x81)
+                return bytearray(b"\xea\x81")
+            if calls == 2:
+                # Extended state: 21 bytes total, first 2 already read
+                self.assertEqual(expected, 19)
+                return bytearray(
+                    b"\x01\x00\xb6\x01\x23\x61\x00\x64\x0f\x00\x00\x00\x64\x64\x00\x00\x00\x00\x83"
+                )
+
+        mock_read.side_effect = read_data
+        light = flux_led.WifiLedBulb("192.168.1.164")
+
+        assert light.color_modes == {COLOR_MODE_RGB, COLOR_MODE_DIM}
+        self.assertEqual(light.protocol, PROTOCOL_LEDENET_EXTENDED_CUSTOM)
+        self.assertEqual(light.model_num, 0xB6)
+        assert "Surplife" in light.model
+        assert light.supports_extended_custom_effects is True
+
+        # Basic function: on/off issue a standard power command.
+        mock_send.reset_mock()
+        light.turnOn()
+        assert mock_send.called
+        light.turnOff()
+        assert mock_send.called
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1440,8 +1440,9 @@ class TestLight(unittest.TestCase):
             if calls == 2:
                 # Extended state: 21 bytes total, first 2 already read
                 self.assertEqual(expected, 19)
+                # Byte 18 (extended-state LED-count position) = 0x64 -> 100.
                 return bytearray(
-                    b"\x01\x00\xb6\x01\x23\x61\x00\x64\x0f\x00\x00\x00\x64\x64\x00\x00\x00\x00\x83"
+                    b"\x01\x00\xb6\x01\x23\x61\x00\x64\x0f\x00\x00\x00\x64\x64\x00\x00\x64\x00\x83"
                 )
 
         mock_read.side_effect = read_data
@@ -1452,6 +1453,8 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.model_num, 0xB6)
         assert "Surplife" in light.model
         assert light.supports_extended_custom_effects is True
+        # The configured LED count is exposed on the sync path too.
+        self.assertEqual(light.led_count, 100)
 
         # Basic function: on/off issue a standard power command.
         mock_send.reset_mock()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1438,11 +1438,11 @@ class TestLight(unittest.TestCase):
                 # 0xB6 device returns extended state format (0xEA 0x81)
                 return bytearray(b"\xea\x81")
             if calls == 2:
-                # Extended state: 21 bytes total, first 2 already read
-                self.assertEqual(expected, 19)
+                # Extended state: 27 bytes total, first 2 already read
+                self.assertEqual(expected, 25)
                 # Byte 18 (extended-state LED-count position) = 0x64 -> 100.
                 return bytearray(
-                    b"\x01\x00\xb6\x01\x23\x61\x00\x64\x0f\x00\x00\x00\x64\x64\x00\x00\x64\x00\x83"
+                    b"\x01\x00\xb6\x09\x24\x66\x01\x64\xf0\x00\x00\x00\x00\x64\x05\x00\x64\x00\x00\x00\x20\x02\x01\x00\x03"
                 )
 
         mock_read.side_effect = read_data

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1463,6 +1463,27 @@ class TestLight(unittest.TestCase):
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")
     @patch("flux_led.WifiLedBulb.connect")
+    def test_determine_protocol_invalid_response_raises(
+        self, mock_connect, mock_read, mock_send
+    ):
+        """If no probe yields a valid (standard or extended) state, raise.
+
+        Exercises the ``not (is_valid_state_response or
+        is_valid_extended_state_response)`` branch (the extended check is the
+        0xB6 addition) and the final 'Cannot determine protocol' raise.
+        """
+
+        def read_data(expected):
+            # Non-0xEA, non-state garbage: fails both validators for every probe.
+            return bytearray(b"\x99" * expected)
+
+        mock_read.side_effect = read_data
+        with self.assertRaisesRegex(Exception, "Cannot determine protocol"):
+            flux_led.WifiLedBulb("192.168.1.199")
+
+    @patch("flux_led.WifiLedBulb._send_msg")
+    @patch("flux_led.WifiLedBulb._read_msg")
+    @patch("flux_led.WifiLedBulb.connect")
     def test_rgbcw_bulb_v9(self, mock_connect, mock_read, mock_send):
         calls = 0
 


### PR DESCRIPTION
**Merge order:** #538 → this → effects-api → timers → cli. Draft until #538 lands.

The 0xB6 replies **only** with the extended state frame (`0xEA 0x81`), never the standard `0x81`. #538 made basic on/off work by reusing `ProtocolLEDENET25Byte` (which already parses that frame). This PR introduces the device's own protocol class so the effect/segment/scribble/timer methods (later PRs) have a home, and exposes the configured pixel count.

### Changes
| File | What / why |
|------|------------|
| `protocol.py` (+110) | New **`ProtocolLEDENETExtendedCustom`** (subclass of `ProtocolLEDENET25Byte`). Adds the 21-byte extended-state probe fork, `named_raw_state` extended conversion, and `extended_state_led_count()` (+ `LEDENET_EXTENDED_STATE_LED_COUNT_POS`). |
| `base_device.py` (+17) | Store the parsed LED count in `process_extended_state_response`; add the `led_count` property and `supports_extended_custom_effects`. |
| `device.py` (+13) | Sync-path support for the extended protocol (probe/state handling). |
| `models_db.py` (±10) | Repoint 0xB6 to `PROTOCOL_LEDENET_EXTENDED_CUSTOM`. |
| `tests/test_aio.py` (+75), `tests/test_sync.py` (+38) | Protocol/state/`led_count` tests, incl. real captured frames. |

### Protocol: extended state response (`EA 81`, 27 bytes, after unwrap)
```
ea 81 01 00 b6 09 [PWR] 66 01 64 f0 00 00 00 00 64 05 00 [COUNT] 00 00 00 20 02 01 00 03
 0  1  2  3  4  5    6    7  8  9 10                15 16 17   18
```
- byte 4 = model (`b6`), byte 5 = fw version (`9`), byte 6 = power (`0x23` on / `0x24` off),  byte 7 = preset (`0x66` in scribble/static), byte **18** = **configured LED count**  (`0x64`=100, `0x50`=80, verified against two real frames).

### Testing
- `test_extended_state_led_count`: asserts `100` and `80` from the two captured frames and `None` for an invalid/short frame. Existing protocol/state tests extended for 0xB6.
- `pytest` green, `ruff` clean, no new `mypy` errors.

**On-device verification** (device `192.168.1.78`):
| Check | Command | Result |
|-------|---------|--------|
| Discovery | `flux_led -s` | ✅ found `7C3E821AE33F` / 192.168.1.78 |
| Info / state / model | `flux_led <ip> -i` | ✅ recognized as 0xB6 "Surplife Outdoor Permanent Lighting"; power + state parsed |
| Power | `--on` / `--off` | ✅ strip on / dark |
| LED count | toggled device 100→80 | ✅ `led_count` (state byte 18) tracked the change; bitmap sizing follows |