### PR TITLE
feat: CLI for 0xB6 extended effects, segments, scribble, and timers

### DIFF
--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -49,11 +49,12 @@ from .protocol import (
     ProtocolLEDENET8Byte,
     ProtocolLEDENETAddressableA3,
     ProtocolLEDENETAddressableChristmas,
+    ProtocolLEDENETExtendedCustom,
     ProtocolLEDENETOriginal,
     RemoteConfig,
 )
 from .scanner import FluxLEDDiscovery
-from .timer import LedTimer
+from .timer import LedTimer, LedTimerExtended
 from .utils import color_temp_to_white_levels, rgbw_brightness, rgbww_brightness
 
 _LOGGER = logging.getLogger(__name__)
@@ -87,7 +88,7 @@ class AIOWifiLedBulb(LEDENETDevice):
         self._get_time_future: asyncio.Future[bool] | None = None
         self._get_timers_lock: asyncio.Lock = asyncio.Lock()
         self._get_timers_future: asyncio.Future[bool] | None = None
-        self._timers: list[LedTimer] | None = None
+        self._timers: list[LedTimer] | list[LedTimerExtended] | None = None
         self._power_restore_future: asyncio.Future[bool] = loop.create_future()
         self._device_config_lock: asyncio.Lock = asyncio.Lock()
         self._device_config_future: asyncio.Future[bool] = loop.create_future()
@@ -711,7 +712,7 @@ class AIOWifiLedBulb(LEDENETDevice):
                 return None
             return self._last_time
 
-    async def async_get_timers(self) -> list[LedTimer] | None:
+    async def async_get_timers(self) -> list[LedTimer] | list[LedTimerExtended] | None:
         """Get the timers."""
         assert self._protocol is not None
         if isinstance(self._protocol, ProtocolLEDENETOriginal):
@@ -728,10 +729,24 @@ class AIOWifiLedBulb(LEDENETDevice):
                 return None
             return self._timers
 
-    async def async_set_timers(self, timer_list: list[LedTimer]) -> None:
+    async def async_set_timers(
+        self, timer_list: list[LedTimer] | list[LedTimerExtended]
+    ) -> None:
         """Set the timers."""
         assert self._protocol is not None
-        await self._async_send_msg(self._protocol.construct_set_timers(timer_list))
+        if isinstance(self._protocol, ProtocolLEDENETExtendedCustom):
+            # 0xB6 devices set timers one at a time
+            commands = self._protocol.construct_set_timers(timer_list)  # type: ignore[arg-type]
+            for cmd in commands:
+                await self._async_send_msg(cmd)
+        else:
+            await self._async_send_msg(self._protocol.construct_set_timers(timer_list))  # type: ignore[arg-type]
+
+    async def async_set_timer(self, timer: LedTimerExtended) -> None:
+        """Set a single timer (for 0xB6 devices)."""
+        assert self._protocol is not None
+        if isinstance(self._protocol, ProtocolLEDENETExtendedCustom):
+            await self._async_send_msg(self._protocol.construct_set_timer(timer))
 
     async def async_set_time(self, time: datetime | None = None) -> None:
         """Set the current time."""

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -422,6 +422,47 @@ class AIOWifiLedBulb(LEDENETDevice):
             self._generate_custom_patterm(rgb_list, speed, transition_type)
         )
 
+    async def async_set_extended_custom_effect(
+        self,
+        pattern_id: int,
+        colors: list[tuple[int, int, int]],
+        speed: int = 50,
+        density: int = 50,
+        direction: int = 0x01,
+        option: int = 0x00,
+    ) -> None:
+        """Set an extended custom effect on the device.
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+
+        Args:
+            pattern_id: Pattern ID (1-24 or 101-102). See ExtendedCustomEffectPattern.
+            colors: List of 1-8 RGB color tuples
+            speed: Animation speed 0-100 (default 50)
+            density: Pattern density 0-100 (default 50)
+            direction: Animation direction (0x01=L->R, 0x02=R->L)
+            option: Pattern-specific option (default 0)
+        """
+        await self._async_send_msg(
+            self._generate_extended_custom_effect(
+                pattern_id, colors, speed, density, direction, option
+            )
+        )
+
+    async def async_set_custom_segment_colors(
+        self,
+        segments: list[tuple[int, int, int] | None],
+    ) -> None:
+        """Set custom colors for each segment on the device.
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+        Sets static HSV colors for each of 20 segments on the light strip.
+
+        Args:
+            segments: List of up to 20 segment colors. Each is (R, G, B) or None for off.
+        """
+        await self._async_send_msg(self._generate_custom_segment_colors(segments))
+
     async def async_set_effect(
         self, effect: str, speed: int, brightness: int = 100
     ) -> None:

--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -34,7 +34,10 @@ from .const import (
     STATE_GREEN,
     STATE_RED,
     STATE_WARM_WHITE,
+    ExtendedCustomEffectDirection,
     MultiColorEffects,
+    ScribbleEffect,
+    ScribbleLED,
 )
 from .protocol import (
     POWER_RESTORE_BYTES_TO_POWER_RESTORE,
@@ -462,6 +465,38 @@ class AIOWifiLedBulb(LEDENETDevice):
             segments: List of up to 20 segment colors. Each is (R, G, B) or None for off.
         """
         await self._async_send_msg(self._generate_custom_segment_colors(segments))
+
+    async def async_set_scribble(
+        self,
+        leds: list[ScribbleLED],
+        effect: ScribbleEffect | int = ScribbleEffect.STATIC,
+        direction: ExtendedCustomEffectDirection = (
+            ExtendedCustomEffectDirection.LEFT_TO_RIGHT
+        ),
+        density: int = 80,
+        speed: int = 100,
+        enter_mode: bool = True,
+    ) -> None:
+        """Set a per-LED ('scribble') configuration on a 0xB6 device.
+
+        Renders every LED via grouped E1 26 paints (one per color/blink group),
+        covering all N LEDs including an (0,0,0) group for off bulbs. Per-LED
+        blink/color come from each ScribbleLED. ``effect`` is a ScribbleEffect or
+        a raw int id 0x00-0x08 (ids 3,4,6,7 are valid effects with no UI name).
+        When enter_mode is True, first sends one all-zero E1 23 to guarantee
+        scribble-mode entry from another mode (E1 26 alone also works when
+        already in scribble). E1 23 does NOT render -- all colors render through
+        E1 26 (verified on hardware).
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+        """
+        num_leds = self.led_count or len(leds)
+        if enter_mode:
+            await self._async_send_msg(self._generate_scribble_init(num_leds))
+        for msg in self._scribble_paint_groups(
+            leds, effect, direction.value, density, speed, num_leds
+        ):
+            await self._async_send_msg(msg)
 
     async def async_set_effect(
         self, effect: str, speed: int, brightness: int = 100

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -250,6 +250,7 @@ class LEDENETDevice:
         self._device_config: LEDENETAddressableDeviceConfiguration | None = None
         self._last_message: dict[str, bytes] = {}
         self._unavailable_reason: str | None = None
+        self._extended_led_count: int | None = None
 
     def _protocol_probes(
         self,
@@ -488,6 +489,11 @@ class LEDENETDevice:
         if self._device_config is None:
             return None
         return self._device_config.music_segments
+
+    @property
+    def led_count(self) -> int | None:
+        """Return the device's configured LED count (0xB6), or None if unknown."""
+        return self._extended_led_count
 
     @property
     def wiring(self) -> str | None:
@@ -868,6 +874,8 @@ class LEDENETDevice:
     def process_extended_state_response(self, msg: bytes) -> bool:
         """Process and extended state response."""
         assert self._protocol is not None
+        if isinstance(self._protocol, ProtocolLEDENETExtendedCustom):
+            self._extended_led_count = self._protocol.extended_state_led_count(msg)
         self._process_valid_state_response(self._protocol.extended_state_to_state(msg))
         return True
 

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -90,6 +90,7 @@ from .protocol import (
     PROTOCOL_LEDENET_ADDRESSABLE_CHRISTMAS,
     PROTOCOL_LEDENET_CCT,
     PROTOCOL_LEDENET_CCT_WRAPPED,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM,
     PROTOCOL_LEDENET_ORIGINAL,
     PROTOCOL_LEDENET_ORIGINAL_CCT,
     PROTOCOL_LEDENET_ORIGINAL_RGBW,
@@ -110,6 +111,7 @@ from .protocol import (
     ProtocolLEDENETAddressableChristmas,
     ProtocolLEDENETCCT,
     ProtocolLEDENETCCTWrapped,
+    ProtocolLEDENETExtendedCustom,
     ProtocolLEDENETOriginal,
     ProtocolLEDENETOriginalCCT,
     ProtocolLEDENETOriginalRGBW,
@@ -143,6 +145,7 @@ PROTOCOL_TYPES = (
     | ProtocolLEDENET9ByteAutoOn
     | ProtocolLEDENET9ByteDimmableEffects
     | ProtocolLEDENET25Byte
+    | ProtocolLEDENETExtendedCustom
     | ProtocolLEDENETAddressableA1
     | ProtocolLEDENETAddressableA2
     | ProtocolLEDENETAddressableA3
@@ -187,6 +190,7 @@ PROTOCOL_NAME_TO_CLS = {
     PROTOCOL_LEDENET_9BYTE_AUTO_ON: ProtocolLEDENET9ByteAutoOn,
     PROTOCOL_LEDENET_9BYTE_DIMMABLE_EFFECTS: ProtocolLEDENET9ByteDimmableEffects,
     PROTOCOL_LEDENET_25BYTE: ProtocolLEDENET25Byte,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM: ProtocolLEDENETExtendedCustom,
     PROTOCOL_LEDENET_ADDRESSABLE_A3: ProtocolLEDENETAddressableA3,
     PROTOCOL_LEDENET_ADDRESSABLE_A2: ProtocolLEDENETAddressableA2,
     PROTOCOL_LEDENET_ADDRESSABLE_A1: ProtocolLEDENETAddressableA1,
@@ -637,6 +641,11 @@ class LEDENETDevice:
         if self.microphone:
             return [*effects, EFFECT_RANDOM, EFFECT_MUSIC]
         return [*effects, EFFECT_RANDOM]
+
+    @property
+    def supports_extended_custom_effects(self) -> bool:
+        """Return True if the device uses the extended custom protocol."""
+        return self.protocol == PROTOCOL_LEDENET_EXTENDED_CUSTOM
 
     @property
     def effect(self) -> str | None:

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -49,6 +49,7 @@ from .const import (  # imported for back compat, remove once Home Assistant no 
     STATE_RED,
     STATE_WARM_WHITE,
     STATIC_MODES,
+    ExtendedCustomEffectPattern,
     WhiteChannelType,
 )
 from .models_db import (
@@ -72,6 +73,7 @@ from .pattern import (
     EFFECT_LIST,
     EFFECT_LIST_DIMMABLE,
     EFFECT_LIST_LEGACY_CCT,
+    EXTENDED_CUSTOM_EFFECT_ID_NAME,
     ORIGINAL_ADDRESSABLE_EFFECT_ID_NAME,
     ORIGINAL_ADDRESSABLE_EFFECT_NAME_ID,
     PresetPattern,
@@ -654,6 +656,13 @@ class LEDENETDevice:
         return self.protocol == PROTOCOL_LEDENET_EXTENDED_CUSTOM
 
     @property
+    def extended_custom_effect_pattern_list(self) -> list[str] | None:
+        """Return available extended custom effect patterns, or None if not supported."""
+        if not self.supports_extended_custom_effects:
+            return None
+        return [p.name.lower().replace("_", " ") for p in ExtendedCustomEffectPattern]
+
+    @property
     def effect(self) -> str | None:
         """Return the current effect."""
         if self.protocol in CHRISTMAS_EFFECTS_PROTOCOLS:
@@ -667,6 +676,16 @@ class LEDENETDevice:
         mode = self.raw_state.mode
         pattern_code = self.preset_pattern_num
         protocol = self.protocol
+        # Devices with extended custom effects use different pattern names
+        if self.supports_extended_custom_effects and pattern_code == 0x25:
+            return EXTENDED_CUSTOM_EFFECT_ID_NAME.get(mode)
+        # For 0xB6 segment mode: preset_pattern=0x24 and mode=0x00
+        if (
+            self.supports_extended_custom_effects
+            and pattern_code == 0x24
+            and mode == 0x00
+        ):
+            return EXTENDED_CUSTOM_EFFECT_ID_NAME.get(mode)  # Returns "Segments"
         if protocol in OLD_EFFECTS_PROTOCOLS:
             effect_id = (pattern_code << 8) + mode - 99
             return ORIGINAL_ADDRESSABLE_EFFECT_ID_NAME.get(effect_id)
@@ -1318,6 +1337,79 @@ class LEDENETDevice:
 
         assert self._protocol is not None
         return self._protocol.construct_custom_effect(rgb_list, speed, transition_type)
+
+    def _generate_extended_custom_effect(
+        self,
+        pattern_id: int,
+        colors: list[tuple[int, int, int]],
+        speed: int = 50,
+        density: int = 50,
+        direction: int = 0x01,
+        option: int = 0x00,
+    ) -> bytearray:
+        """Generate the extended custom effect protocol bytes with validation.
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+        """
+        # Validate pattern_id
+        valid_ids = set(range(1, 25)) | {101, 102}
+        if pattern_id not in valid_ids:
+            raise ValueError(f"Pattern ID must be 1-24 or 101-102, got {pattern_id}")
+
+        # Truncate if more than 8 colors
+        if len(colors) > 8:
+            _LOGGER.warning(
+                "Too many colors in %s, truncating list to %s", len(colors), 8
+            )
+            colors = colors[:8]
+
+        # Require at least one color
+        if len(colors) == 0:
+            raise ValueError("Surplife pattern requires at least one color")
+
+        # Validate color tuples
+        for idx, color in enumerate(colors):
+            if len(color) != 3:
+                raise ValueError(f"Color {idx} must be (R, G, B) tuple")
+            for c in color:
+                if not 0 <= c <= 255:
+                    raise ValueError(f"Color values must be 0-255, got {c}")
+
+        assert self._protocol is not None
+        assert isinstance(self._protocol, ProtocolLEDENETExtendedCustom)
+        return self._protocol.construct_extended_custom_effect(
+            pattern_id, colors, speed, density, direction, option
+        )
+
+    def _generate_custom_segment_colors(
+        self,
+        segments: list[tuple[int, int, int] | None],
+    ) -> bytearray:
+        """Generate custom segment colors protocol bytes with validation.
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+
+        Args:
+            segments: List of up to 20 segment colors. Each is (R, G, B) or None for off.
+        """
+        # Truncate if more than 20 segments
+        if len(segments) > 20:
+            _LOGGER.warning("Too many segments (%s), truncating to 20", len(segments))
+            segments = segments[:20]
+
+        # Validate color tuples
+        for idx, color in enumerate(segments):
+            if color is None:
+                continue
+            if len(color) != 3:
+                raise ValueError(f"Segment {idx} must be (R, G, B) tuple or None")
+            for c in color:
+                if not 0 <= c <= 255:
+                    raise ValueError(f"Color values must be 0-255, got {c}")
+
+        assert self._protocol is not None
+        assert isinstance(self._protocol, ProtocolLEDENETExtendedCustom)
+        return self._protocol.construct_custom_segment_colors(segments)
 
     def _effect_to_pattern(self, effect: str) -> int:
         """Convert an effect to a pattern code."""

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -50,6 +50,9 @@ from .const import (  # imported for back compat, remove once Home Assistant no 
     STATE_WARM_WHITE,
     STATIC_MODES,
     ExtendedCustomEffectPattern,
+    ScribbleBlinkMode,
+    ScribbleEffect,
+    ScribbleLED,
     WhiteChannelType,
 )
 from .models_db import (
@@ -653,6 +656,11 @@ class LEDENETDevice:
     @property
     def supports_extended_custom_effects(self) -> bool:
         """Return True if the device uses the extended custom protocol."""
+        return self.protocol == PROTOCOL_LEDENET_EXTENDED_CUSTOM
+
+    @property
+    def supports_scribble(self) -> bool:
+        """Return True if the device supports the per-LED scribble feature."""
         return self.protocol == PROTOCOL_LEDENET_EXTENDED_CUSTOM
 
     @property
@@ -1410,6 +1418,145 @@ class LEDENETDevice:
         assert self._protocol is not None
         assert isinstance(self._protocol, ProtocolLEDENETExtendedCustom)
         return self._protocol.construct_custom_segment_colors(segments)
+
+    def _generate_scribble_init(self, num_leds: int) -> bytearray:
+        """Generate the scribble-mode init (E1 23, non-rendering) bytes.
+
+        E1 23 does not render -- it only guarantees scribble-mode entry. Colors
+        render through grouped E1 26 paints (see _scribble_paint_groups).
+        """
+        # The E1 23 byte-8 count and the E1 26 bitmap sizing are one-byte /
+        # ceil(N/8) fields; N is unrepresentable above 255 on the wire.
+        if not 0 < num_leds <= 255:
+            raise ValueError(f"num_leds must be 1..255, got {num_leds}")
+        assert self._protocol is not None
+        assert isinstance(self._protocol, ProtocolLEDENETExtendedCustom)
+        return self._protocol.construct_scribble_init(num_leds)
+
+    def _generate_scribble_paint(
+        self,
+        effect: int,
+        direction: int,
+        density: int,
+        speed: int,
+        color: tuple[int, int, int] | None,
+        white: int | None,
+        blink_mode: int,
+        blink_speed: int,
+        led_indices: list[int] | None,
+        num_leds: int,
+    ) -> bytearray:
+        """Generate a single scribble paint (E1 26) for one color/blink group.
+
+        Color and white are mutually exclusive. Colors are converted to
+        (H/2, S, V) via the existing _rgb_to_hsv_bytes helper.
+        """
+        if color is not None and white is not None:
+            raise ValueError("color and white are mutually exclusive")
+        assert self._protocol is not None
+        assert isinstance(self._protocol, ProtocolLEDENETExtendedCustom)
+        if color is not None:
+            h2, s, v = self._protocol._rgb_to_hsv_bytes(*color)[:3]
+            white_level = 0
+        else:
+            h2 = s = v = 0
+            white_level = white or 0
+        if led_indices is not None:
+            for i in led_indices:
+                if not 0 <= i < num_leds:
+                    raise ValueError(f"LED index {i} out of range for {num_leds} LEDs")
+        return self._protocol.construct_scribble_paint(
+            effect=effect,
+            direction=direction,
+            density=density,
+            speed=speed,
+            blink_mode=blink_mode,
+            h2=h2,
+            s=s,
+            v=v,
+            white=white_level,
+            blink_speed=blink_speed,
+            bitmap_leds=led_indices,
+            num_leds=num_leds,
+        )
+
+    def _scribble_paint_groups(
+        self,
+        leds: list[ScribbleLED],
+        effect: ScribbleEffect | int,
+        direction: int,
+        density: int,
+        speed: int,
+        num_leds: int,
+    ) -> list[bytearray]:
+        """Group per-LED settings and return one E1 26 paint per group.
+
+        This is the primary render path for every scribble call (E1 23 does
+        not render). LEDs are grouped by (rgb, white, blink_mode, blink_speed)
+        in first-appearance order; an off LED (rgb None, white None) is painted
+        as color (0,0,0). The union of all group bitmaps covers exactly the N
+        LEDs, so the result is deterministic regardless of prior device state.
+        """
+        if not leds:
+            raise ValueError("leds must not be empty")
+        if not 0 < num_leds <= 255:
+            raise ValueError(f"num_leds must be 1..255, got {num_leds}")
+        if self.led_count is not None and self.led_count != len(leds):
+            raise ValueError(f"Got {len(leds)} LEDs but device has {self.led_count}")
+        if num_leds != len(leds):
+            raise ValueError(f"num_leds {num_leds} does not match {len(leds)} LEDs")
+
+        # effect may be a ScribbleEffect (the 5 named ones) or a raw int id.
+        # The device accepts effect ids 0x00-0x08 (verified on-device); ids 3,4,
+        # 6,7 are valid effects with no UI name, reachable only as raw ints.
+        effect_id = effect.value if isinstance(effect, ScribbleEffect) else int(effect)
+        if not 0x00 <= effect_id <= 0x08:
+            raise ValueError(f"scribble effect id must be 0x00-0x08, got {effect_id}")
+
+        # Validate per-LED settings and bucket indices by group key.
+        groups: dict[
+            tuple[tuple[int, int, int] | None, int | None, ScribbleBlinkMode, int],
+            list[int],
+        ] = {}
+        for idx, led in enumerate(leds):
+            if led.rgb is not None and led.white is not None:
+                raise ValueError(f"LED {idx}: rgb and white are mutually exclusive")
+            if led.rgb is not None:
+                if len(led.rgb) != 3 or any(not 0 <= c <= 255 for c in led.rgb):
+                    raise ValueError(f"LED {idx}: rgb values must be 0-255")
+            if led.white is not None and not 0 <= led.white <= 100:
+                raise ValueError(f"LED {idx}: white must be 0-100")
+            if not 0 <= led.blink_speed <= 100:
+                raise ValueError(f"LED {idx}: blink_speed must be 0-100")
+            key = (led.rgb, led.white, led.blink_mode, led.blink_speed)
+            groups.setdefault(key, []).append(idx)
+
+        messages: list[bytearray] = []
+        for (rgb, white, blink_mode, blink_speed), indices in groups.items():
+            # Off LEDs (rgb None and white None) paint as color (0,0,0).
+            color: tuple[int, int, int] | None
+            paint_white: int | None
+            if rgb is None and white is None:
+                color = (0, 0, 0)
+                paint_white = None
+            else:
+                color = rgb
+                paint_white = white
+            messages.append(
+                self._generate_scribble_paint(
+                    effect=effect_id,
+                    direction=direction,
+                    density=density,
+                    speed=speed,
+                    color=color,
+                    white=paint_white,
+                    blink_mode=blink_mode.value,
+                    blink_speed=blink_speed,
+                    led_indices=indices,
+                    num_leds=num_leds,
+                )
+            )
+        return messages
 
     def _effect_to_pattern(self, effect: str) -> int:
         """Convert an effect to a pattern code."""

--- a/flux_led/const.py
+++ b/flux_led/const.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Final  # pylint: disable=no-name-in-module
+from typing import Final, NamedTuple  # pylint: disable=no-name-in-module
 
 MIN_TEMP: Final = 2700
 MAX_TEMP: Final = 6500
@@ -85,6 +85,52 @@ class ExtendedCustomEffectOption(Enum):
     DEFAULT = 0x00
     VARIANT_1 = 0x01
     VARIANT_2 = 0x02
+
+
+class ScribbleEffect(Enum):
+    """Global effect id for the scribble feature (E1 26 byte 2).
+
+    Distinct from ExtendedCustomEffectPattern (E1 21). Byte-2 gaps (0x04,
+    0x06, 0x07, ...) imply more effects/variants than the UI exposes.
+    """
+
+    STATIC = 0x00
+    FLOWING = 0x01
+    TWINKLING_STARS = 0x02
+    TWINKLING_STARS_VARIANT = 0x03
+    STARS_WINK = 0x05
+    ACCUMULATE = 0x08
+
+
+class ScribbleBlinkMode(Enum):
+    """Blink mode for the scribble global command (E1 26 byte 6)."""
+
+    NONE = 0x00
+    SLOW = 0x08
+    FAST = 0x10
+
+
+class ScribbleLED(NamedTuple):
+    """One LED's setting in a scribble (per-LED) configuration.
+
+    Color and white are mutually exclusive:
+      * rgb set, white None  -> color mode; brightness is the RGB value itself
+        (the E1 26 V byte is derived from the RGB tuple)
+      * white set, rgb None  -> white mode; the white level (0-100) is the
+        brightness (the E1 26 WLVL byte)
+      * both None            -> LED off (painted as color (0,0,0))
+
+    Per-LED blink is achieved by grouping: LEDs sharing a
+    (blink_mode, blink_speed) are painted by one E1 26 and blink independently
+    per group. These are real, rendered fields that flow into the group key
+    and the E1 26 paint (the E1 23 init carries no color/blink and does not
+    render, so they never go into an E1 23 record).
+    """
+
+    rgb: tuple[int, int, int] | None = None  # (R,G,B) 0-255, or None
+    white: int | None = None  # warm-white level 0-100, or None
+    blink_mode: ScribbleBlinkMode = ScribbleBlinkMode.NONE  # E1 26 byte 6
+    blink_speed: int = 100  # 0-100, only meaningful when blinking
 
 
 DEFAULT_WHITE_CHANNEL_TYPE: Final = WhiteChannelType.WARM

--- a/flux_led/const.py
+++ b/flux_led/const.py
@@ -38,6 +38,55 @@ class MultiColorEffects(Enum):
     BREATHING = 0x05
 
 
+class ExtendedCustomEffectPattern(Enum):
+    """Pattern IDs for extended custom effects (e.g., 0xB6 device)."""
+
+    WAVE = 0x01
+    METEOR = 0x02
+    STREAMER = 0x03
+    BUILDING_BLOCKS = 0x04
+    FLOWING_WATER = 0x05
+    CHASE = 0x06
+    HORSE_RACING = 0x07
+    CYCLE = 0x08
+    BREATHE = 0x09
+    JUMP = 0x0A
+    STROBE = 0x0B
+    TWINKLING_STARS = 0x0C
+    STARS_WINK = 0x0D
+    WARNING = 0x0E
+    COLLISION = 0x0F
+    FIREWORKS = 0x10
+    COMET = 0x11
+    GRADIENT_METEOR = 0x12
+    VOLCANO = 0x13
+    SUPERLUMINAL = 0x14
+    RAINBOW_BRIDGE = 0x15
+    GRADIENT_OVERLAY = 0x16
+    STATIC_GRADIENT = 0x65
+    STATIC_FILL = 0x66
+
+
+class ExtendedCustomEffectDirection(Enum):
+    """Direction for extended custom effect animations."""
+
+    LEFT_TO_RIGHT = 0x01
+    RIGHT_TO_LEFT = 0x02
+
+
+class ExtendedCustomEffectOption(Enum):
+    """Option values for extended custom effects.
+
+    The meaning varies by pattern:
+    - Some patterns: DEFAULT=static color, VARIANT_1=color change
+    - Rainbow patterns: DEFAULT=strobe, VARIANT_1=twinkle, VARIANT_2=breathe
+    """
+
+    DEFAULT = 0x00
+    VARIANT_1 = 0x01
+    VARIANT_2 = 0x02
+
+
 DEFAULT_WHITE_CHANNEL_TYPE: Final = WhiteChannelType.WARM
 
 PRESET_MUSIC_MODE: Final = 0x62

--- a/flux_led/const.py
+++ b/flux_led/const.py
@@ -256,3 +256,15 @@ MUSIC_PIXELS_PER_SEGMENT_MAX: Final = 150
 PUSH_UPDATE_INTERVAL = 90  # seconds
 
 NEVER_TIME = -PUSH_UPDATE_INTERVAL
+
+
+# Extended Timer Action Types (0xB6 devices)
+TIMER_ACTION_ON: Final = 0x23
+TIMER_ACTION_OFF: Final = 0x24
+TIMER_ACTION_COLOR: Final = 0xA1
+TIMER_ACTION_SCENE_GRADIENT: Final = 0x29
+TIMER_ACTION_SCENE_SEGMENTS: Final = 0x6B
+
+# Extended Timer Effect Types
+TIMER_EFFECT_GRADIENT: Final = 0x21  # e1 21 - gradient overlay
+TIMER_EFFECT_SEGMENTS: Final = 0x22  # e1 22 - static segments/colorful

--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -276,8 +276,17 @@ class WifiLedBulb(LEDENETDevice):
                 # cannot process, recycle the connection
                 self.close()
                 continue
-            full_msg = rx + self._read_msg(protocol.state_response_length - read_bytes)
-            if not protocol.is_valid_state_response(full_msg):
+            # Extended-state-only devices (e.g. 0xB6) reply with 0xEA 0x81 and
+            # need 21 bytes total instead of the standard state length.
+            if rx[0] == 0xEA and rx[1] == 0x81:
+                additional_bytes = 19  # 21 - 2 bytes already read
+            else:
+                additional_bytes = protocol.state_response_length - read_bytes
+            full_msg = rx + self._read_msg(additional_bytes)
+            if not (
+                protocol.is_valid_state_response(full_msg)
+                or protocol.is_valid_extended_state_response(full_msg)
+            ):
                 self.close()
                 continue
             assert isinstance(full_msg, bytearray)

--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -387,5 +387,58 @@ class WifiLedBulb(LEDENETDevice):
             retry=retry,
         )
 
+    def setExtendedCustomEffect(
+        self,
+        pattern_id: int,
+        colors: list[tuple[int, int, int]],
+        speed: int = 50,
+        density: int = 50,
+        direction: int = 0x01,
+        option: int = 0x00,
+        retry: int = DEFAULT_RETRIES,
+    ) -> None:
+        """Set an extended custom effect on the device.
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+
+        Args:
+            pattern_id: Pattern ID (1-24 or 101-102). See ExtendedCustomEffectPattern.
+            colors: List of 1-8 RGB color tuples, e.g., [(255, 0, 0), (0, 255, 0)]
+            speed: Animation speed 0-100 (default 50)
+            density: Pattern density 0-100 (default 50)
+            direction: Animation direction. See ExtendedCustomEffectDirection.
+                0x01 = Left to Right (default)
+                0x02 = Right to Left
+            option: Pattern-specific option (default 0)
+            retry: Number of retries on failure
+        """
+        self._send_and_read_with_retry(
+            self._generate_extended_custom_effect(
+                pattern_id, colors, speed, density, direction, option
+            ),
+            0,
+            retry=retry,
+        )
+
+    def setCustomSegmentColors(
+        self,
+        segments: list[tuple[int, int, int] | None],
+        retry: int = DEFAULT_RETRIES,
+    ) -> None:
+        """Set custom colors for each segment on the device.
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+        Sets static HSV colors for each of 20 segments on the light strip.
+
+        Args:
+            segments: List of up to 20 segment colors. Each is (R, G, B) or None for off.
+            retry: Number of retries on failure
+        """
+        self._send_and_read_with_retry(
+            self._generate_custom_segment_colors(segments),
+            0,
+            retry=retry,
+        )
+
     def refreshState(self) -> None:
         return self.update_state()

--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -18,6 +18,9 @@ from .const import (
     STATE_GREEN,
     STATE_RED,
     STATE_WARM_WHITE,
+    ExtendedCustomEffectDirection,
+    ScribbleEffect,
+    ScribbleLED,
 )
 from .scanner import FluxLEDDiscovery
 from .sock import _socket_retry
@@ -439,6 +442,40 @@ class WifiLedBulb(LEDENETDevice):
             0,
             retry=retry,
         )
+
+    def setScribble(
+        self,
+        leds: list[ScribbleLED],
+        effect: ScribbleEffect | int = ScribbleEffect.STATIC,
+        direction: ExtendedCustomEffectDirection = (
+            ExtendedCustomEffectDirection.LEFT_TO_RIGHT
+        ),
+        density: int = 80,
+        speed: int = 100,
+        enter_mode: bool = True,
+        retry: int = DEFAULT_RETRIES,
+    ) -> None:
+        """Set a per-LED ('scribble') configuration on a 0xB6 device.
+
+        Renders every LED via grouped E1 26 paints (one per color/blink group),
+        covering all N LEDs including an (0,0,0) group for off bulbs. Per-LED
+        blink/color come from each ScribbleLED. ``effect`` is a ScribbleEffect or
+        a raw int id 0x00-0x08 (ids 3,4,6,7 are valid effects with no UI name).
+        When enter_mode is True, first sends one all-zero E1 23 to guarantee
+        scribble-mode entry. E1 23 does NOT render -- all colors render through
+        E1 26 (verified on hardware).
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+        """
+        num_leds = self.led_count or len(leds)
+        if enter_mode:
+            self._send_and_read_with_retry(
+                self._generate_scribble_init(num_leds), 0, retry=retry
+            )
+        for msg in self._scribble_paint_groups(
+            leds, effect, direction.value, density, speed, num_leds
+        ):
+            self._send_and_read_with_retry(msg, 0, retry=retry)
 
     def refreshState(self) -> None:
         return self.update_state()

--- a/flux_led/fluxled.py
+++ b/flux_led/fluxled.py
@@ -45,14 +45,23 @@ import datetime
 import logging
 import sys
 from optparse import OptionGroup, OptionParser, Values
-from typing import Any
+from typing import Any, cast
 
 from .aio import AIOWifiLedBulb
 from .aioscanner import AIOBulbScanner
-from .const import ATTR_ID, ATTR_IPADDR
+from .const import (
+    ATTR_ID,
+    ATTR_IPADDR,
+    TIMER_ACTION_COLOR,
+    TIMER_ACTION_OFF,
+    TIMER_ACTION_ON,
+    ExtendedCustomEffectDirection,
+    ExtendedCustomEffectPattern,
+)
 from .pattern import PresetPattern
+from .protocol import ProtocolLEDENETExtendedCustom
 from .scanner import FluxLEDDiscovery
-from .timer import LedTimer
+from .timer import LedTimer, LedTimerExtended
 from .utils import utils
 
 _LOGGER = logging.getLogger(__name__)
@@ -106,6 +115,15 @@ Set preset pattern #35 with 40% speed:
 
 Set custom pattern 25% speed, red/green/blue, gradual change:
     %prog% 192.168.1.100 -C gradual 25 "red green (0,0,255)"
+
+Set extended custom effect (0xB6 devices) - wave pattern, 80% speed:
+    %prog% 192.168.1.100 -C wave 80 "red green blue"
+
+Set extended effect with density, direction, and color change options:
+    %prog% 192.168.1.100 -C meteor 50 "purple orange" --density 75 --direction r2l --colorchange
+
+Set custom segment colors (0xB6 devices) - set each segment individually:
+    %prog% 192.168.1.100 -C segments 0 "red green blue off off red green blue"
 
 Sync all bulb's clocks with this computer's:
     %prog% -sS --setclock
@@ -355,35 +373,297 @@ def processSetTimerArgs(parser: OptionParser, args: Any) -> LedTimer:
     return timer
 
 
-def processCustomArgs(
-    parser: OptionParser, args: Any
-) -> tuple[Any, int, list[tuple[int, ...]]] | None:
-    if args[0] not in ["gradual", "jump", "strobe"]:
-        parser.error(f"bad pattern type: {args[0]}")
-        return None
+def processSetTimerArgsExtended(
+    parser: OptionParser, args: list[str]
+) -> LedTimerExtended:
+    """Process timer args for 0xB6 extended timer format.
 
-    speed = int(args[1])
+    Supported modes: inactive, default (on), poweroff, color
+    Settings format: mode;time:HHMM;repeat:0123456;color:RRGGBB
+    """
+    num = args[0]
+    mode = args[1].lower() if len(args) > 1 else "inactive"
+    settings = args[2] if len(args) > 2 else ""
 
-    # convert the string to a list of RGB tuples
-    # it should have space separated items of either
-    # color names, hex values, or byte triples
-    try:
-        color_list_str = args[2].strip()
-        str_list = color_list_str.split(" ")
-        color_list = []
-        for s in str_list:
-            c = utils.color_object_to_tuple(s)
-            if c is not None:
-                color_list.append(c)
-            else:
-                raise Exception
+    if not num.isdigit() or int(num) > 6 or int(num) < 1:
+        parser.error("Timer number must be between 1 and 6")
 
-    except Exception:
-        parser.error(
-            "COLORLIST isn't formatted right.  It should be a space separated list of RGB tuples, color names or web hex values"
+    slot = int(num)
+
+    # parse settings
+    settings_dict: dict[str, str] = {}
+    if settings:
+        for s in settings.split(";"):
+            pair = s.split(":")
+            key = pair[0].strip().lower()
+            val = pair[1].strip().lower() if len(pair) > 1 else ""
+            settings_dict[key] = val
+
+    if mode == "inactive":
+        return LedTimerExtended(
+            slot=slot,
+            active=False,
+            hour=0,
+            minute=0,
+            repeat_mask=0,
+            action_type=TIMER_ACTION_OFF,
         )
 
-    return args[0], speed, color_list
+    if mode not in ["poweroff", "default", "color"]:
+        parser.error(
+            f"Not a valid timer mode for this device: {mode}. "
+            "Supported: inactive, default, poweroff, color"
+        )
+
+    # validate time
+    if "time" not in settings_dict:
+        parser.error(f"This mode needs a time: {mode}")
+    time_str = settings_dict["time"]
+    if len(time_str) != 4 or not time_str.isdigit():
+        parser.error("time must be 4 digits (HHMM)")
+    hour = int(time_str[0:2])
+    minute = int(time_str[2:4])
+    if hour > 23:
+        parser.error("timer hour can't be greater than 23")
+    if minute > 59:
+        parser.error("timer minute can't be greater than 59")
+
+    # parse repeat mask
+    # Format: repeat:0123456 where 0=Sun, 1=Mon, ..., 6=Sat
+    repeat_mask = 0
+    if "repeat" in settings_dict:
+        repeat_str = settings_dict["repeat"]
+        for c in repeat_str:
+            if c not in "0123456":
+                parser.error("repeat can only contain digits 0-6")
+            day = int(c)
+            # Map: 0=Sun->bit7, 1=Mon->bit1, 2=Tue->bit2, ..., 6=Sat->bit6
+            if day == 0:
+                repeat_mask |= 0x80  # Sunday = bit 7
+            else:
+                repeat_mask |= 1 << day  # Mon=bit1, Tue=bit2, etc.
+
+    # determine action type and build timer
+    if mode == "poweroff":
+        return LedTimerExtended(
+            slot=slot,
+            active=True,
+            hour=hour,
+            minute=minute,
+            repeat_mask=repeat_mask,
+            action_type=TIMER_ACTION_OFF,
+        )
+
+    if mode == "default":
+        return LedTimerExtended(
+            slot=slot,
+            active=True,
+            hour=hour,
+            minute=minute,
+            repeat_mask=repeat_mask,
+            action_type=TIMER_ACTION_ON,
+        )
+
+    if mode == "color":
+        if "color" not in settings_dict:
+            parser.error("color mode needs a color setting")
+        color_val = settings_dict["color"]
+        # If it looks like hex without # prefix (6 hex chars), add the prefix
+        if len(color_val) == 6 and all(c in "0123456789abcdef" for c in color_val):
+            color_val = "#" + color_val
+        rgb = utils.color_object_to_tuple(color_val)
+        if rgb is None:
+            parser.error(f"Invalid color value: {color_val}")
+        assert rgb is not None
+        # Convert RGB to HSV (0-255 scale)
+        r, g, b = rgb[0], rgb[1], rgb[2]
+        max_c = max(r, g, b)
+        min_c = min(r, g, b)
+        if max_c == 0:
+            hsv_s = 0
+            hsv_h = 0
+        else:
+            hsv_s = int((max_c - min_c) * 255 / max_c)
+            delta = max_c - min_c
+            if delta == 0:
+                hsv_h = 0
+            elif max_c == r:
+                hsv_h = int(((g - b) / delta) * 255 / 6) % 256
+            elif max_c == g:
+                hsv_h = int((2.0 + (b - r) / delta) * 255 / 6) % 256
+            else:
+                hsv_h = int((4.0 + (r - g) / delta) * 255 / 6) % 256
+
+        # brightness from settings or default to 100%
+        brightness = 100
+        if "brightness" in settings_dict:
+            brightness = int(settings_dict["brightness"])
+            brightness = min(brightness, 100)
+
+        return LedTimerExtended(
+            slot=slot,
+            active=True,
+            hour=hour,
+            minute=minute,
+            repeat_mask=repeat_mask,
+            action_type=TIMER_ACTION_COLOR,
+            color_hsv=(hsv_h, hsv_s, brightness),
+        )
+
+    # Should never reach here due to earlier validation
+    parser.error(f"Not a valid timer mode: {mode}")
+    raise SystemExit(1)  # For type checker
+
+
+def processCustomArgs(
+    parser: OptionParser,
+    args: Any,
+    density: int = 50,
+    direction: str = "l2r",
+    colorchange: bool = False,
+) -> dict[str, Any] | None:
+    """Process custom pattern arguments.
+
+    Supports both standard patterns (jump, gradual, strobe) and extended
+    patterns (wave, meteor, etc.) for devices that support them.
+
+    Returns a dict with:
+        - mode: "standard", "extended", or "segments"
+        - For standard: type, speed, colors
+        - For extended: pattern_id, speed, density, colors, direction, option
+        - For segments: colors (list of up to 20 colors)
+    """
+    # Build mapping of extended pattern names to IDs
+    extended_pattern_names = {
+        p.name.lower().replace("_", " "): p.value for p in ExtendedCustomEffectPattern
+    }
+    # Also add underscore versions and single word versions
+    for p in ExtendedCustomEffectPattern:
+        extended_pattern_names[p.name.lower()] = p.value
+
+    pattern_type = args[0].lower()
+    speed = int(args[1])
+
+    # Check if this is a standard pattern
+    if pattern_type in ["gradual", "jump", "strobe"]:
+        # Standard custom pattern
+        try:
+            color_list_str = args[2].strip()
+            str_list = color_list_str.split(" ")
+            color_list: list[tuple[int, ...]] = []
+            for s in str_list:
+                c = utils.color_object_to_tuple(s)
+                if c is not None:
+                    color_list.append(c)
+                else:
+                    raise ValueError(f"Invalid color: {s}")
+        except Exception:
+            parser.error(
+                "COLORLIST isn't formatted right. It should be a space separated list "
+                "of RGB tuples, color names or web hex values"
+            )
+            return None
+
+        return {
+            "mode": "standard",
+            "type": pattern_type,
+            "speed": speed,
+            "colors": color_list,
+        }
+
+    # Check if this is "segments" mode
+    if pattern_type == "segments":
+        try:
+            color_list_str = args[2].strip()
+            str_list = color_list_str.split(" ")
+            segment_list: list[tuple[int, int, int] | None] = []
+            for s in str_list:
+                s = s.strip().lower()
+                if not s:
+                    continue
+                if s == "off":
+                    segment_list.append(None)
+                else:
+                    c = utils.color_object_to_tuple(s)
+                    if c is not None and len(c) >= 3:
+                        segment_list.append((c[0], c[1], c[2]))
+                    else:
+                        raise ValueError(f"Invalid color: {s}")
+            if len(segment_list) == 0:
+                parser.error("At least one segment color is required")
+                return None
+            if len(segment_list) > 20:
+                print("Warning: More than 20 segments provided, truncating to 20")
+                segment_list = segment_list[:20]
+        except Exception as e:
+            parser.error(
+                f"COLORLIST isn't formatted right: {e}. It should be a space-separated "
+                "list of color names, hex values, RGB triples, or 'off'"
+            )
+            return None
+
+        return {
+            "mode": "segments",
+            "colors": segment_list,
+        }
+
+    # Check if this is an extended pattern name
+    if pattern_type in extended_pattern_names:
+        pattern_id = extended_pattern_names[pattern_type]
+
+        # Parse color list
+        try:
+            color_list_str = args[2].strip()
+            str_list = color_list_str.split(" ")
+            ext_color_list: list[tuple[int, int, int]] = []
+            for s in str_list:
+                c = utils.color_object_to_tuple(s)
+                if c is not None and len(c) >= 3:
+                    ext_color_list.append((c[0], c[1], c[2]))
+                else:
+                    raise ValueError(f"Invalid color: {s}")
+            if len(ext_color_list) == 0:
+                parser.error("At least one color is required")
+                return None
+            if len(ext_color_list) > 8:
+                print("Warning: More than 8 colors provided, truncating to 8")
+                ext_color_list = ext_color_list[:8]
+        except Exception as e:
+            parser.error(
+                f"COLORLIST isn't formatted right: {e}. It should be a space-separated "
+                "list of color names, hex values, or RGB triples"
+            )
+            return None
+
+        # Parse direction
+        if direction.lower() in ("l2r", "left", "ltr"):
+            dir_value = ExtendedCustomEffectDirection.LEFT_TO_RIGHT.value
+        elif direction.lower() in ("r2l", "right", "rtl"):
+            dir_value = ExtendedCustomEffectDirection.RIGHT_TO_LEFT.value
+        else:
+            parser.error(f"Invalid direction: {direction}. Use l2r or r2l")
+            return None
+
+        # Option value
+        option_value = 0x01 if colorchange else 0x00
+
+        return {
+            "mode": "extended",
+            "pattern_id": pattern_id,
+            "speed": speed,
+            "density": density,
+            "colors": ext_color_list,
+            "direction": dir_value,
+            "option": option_value,
+        }
+
+    # Unknown pattern type - show valid options
+    parser.error(
+        f"Unknown pattern type: {pattern_type}. Valid types include: "
+        f"jump, gradual, strobe, segments, wave, meteor, breathe, etc. "
+        f"Use --listpresets for the full list."
+    )
+    return None
 
 
 def parseArgs() -> tuple[Values, Any]:
@@ -427,7 +707,7 @@ def parseArgs() -> tuple[Values, Any]:
         action="store_true",
         dest="listpresets",
         default=False,
-        help="List preset codes",
+        help="List preset codes (including extended patterns for 0xB6 devices)",
     )
     info_group.add_option(
         "--listcolors",
@@ -527,10 +807,36 @@ def parseArgs() -> tuple[Values, Any]:
         default=None,
         nargs=3,
         help="Set custom pattern mode. "
-        + "TYPE should be jump, gradual, or strobe. SPEED is percent. "
-        + "COLORLIST is a space-separated list of color names, web hex values, or comma-separated RGB triples",
+        + "TYPE: jump, gradual, strobe (standard), or extended pattern names "
+        + "(wave, meteor, breathe, etc. for 0xB6 devices), or 'segments' for static colors. "
+        + "SPEED is percent (0-100). "
+        + "COLORLIST is a space-separated list of color names, hex values, or RGB triples. "
+        + "Use --density, --direction, --colorchange for extended pattern options.",
     )
     parser.add_option_group(mode_group)
+
+    other_group.add_option(
+        "--density",
+        dest="density",
+        default=50,
+        type="int",
+        metavar="DENSITY",
+        help="Pattern density 0-100 for extended effects (default: 50)",
+    )
+    other_group.add_option(
+        "--direction",
+        dest="direction",
+        default="l2r",
+        metavar="DIR",
+        help="Direction for extended effect: l2r (left to right) or r2l (right to left). Default: l2r",
+    )
+    other_group.add_option(
+        "--colorchange",
+        action="store_true",
+        dest="colorchange",
+        default=False,
+        help="Enable color change option for extended effect",
+    )
 
     parser.add_option(
         "-i",
@@ -611,10 +917,20 @@ def parseArgs() -> tuple[Values, Any]:
         sys.exit(0)
 
     if options.listpresets:
+        print("Standard preset patterns (-p option):")
         for c in range(
             PresetPattern.seven_color_cross_fade, PresetPattern.seven_color_jumping + 1
         ):
-            print(f"{c:2} {PresetPattern.valtostr(c)}")
+            print(f"  {c:2} {PresetPattern.valtostr(c)}")
+        print("\nStandard custom pattern types (-C option):")
+        print("  jump     - Colors change instantly")
+        print("  gradual  - Colors fade smoothly")
+        print("  strobe   - Colors flash rapidly")
+        print("\nExtended custom patterns (-C option, 0xB6 devices only):")
+        for p in ExtendedCustomEffectPattern:
+            print(f"  {p.name.lower().replace('_', ' '):<20} (ID: {p.value})")
+        print("\nSegment colors (-C segments, 0xB6 devices only):")
+        print("  segments - Set individual segment colors (up to 20)")
         sys.exit(0)
 
     if options.listcolors:
@@ -623,11 +939,9 @@ def parseArgs() -> tuple[Values, Any]:
         print()
         sys.exit(0)
 
-    if options.settimer:
-        new_timer = processSetTimerArgs(parser, options.settimer)
-        options.new_timer = new_timer
-    else:
-        options.new_timer = None
+    # Timer processing is deferred to _async_run_commands since we need
+    # to know the device protocol first (0xB6 uses extended timer format)
+    options.new_timer = None
 
     mode_count = 0
     if options.color:
@@ -651,7 +965,13 @@ def parseArgs() -> tuple[Values, Any]:
         parser.error("options --on and --off are mutually exclusive")
 
     if options.custom:
-        options.custom = processCustomArgs(parser, options.custom)
+        options.custom = processCustomArgs(
+            parser,
+            options.custom,
+            density=options.density,
+            direction=options.direction,
+            colorchange=options.colorchange,
+        )
 
     if options.color:
         options.color = utils.color_object_to_tuple(options.color)
@@ -782,12 +1102,67 @@ async def _async_run_commands(
             )
 
     elif options.custom is not None:
-        await bulb.async_set_custom_pattern(
-            options.custom[2], options.custom[1], options.custom[0]
-        )
-        buf_in(
-            f"Setting custom pattern: {options.custom[0]}, Speed={options.custom[1]}%, {options.custom[2]}"
-        )
+        custom = options.custom
+        mode = custom["mode"]
+
+        if mode == "standard":
+            # Standard custom pattern (jump, gradual, strobe)
+            await bulb.async_set_custom_pattern(
+                custom["colors"], custom["speed"], custom["type"]
+            )
+            buf_in(
+                f"Setting custom pattern: {custom['type']}, "
+                f"Speed={custom['speed']}%, {custom['colors']}"
+            )
+
+        elif mode == "extended":
+            # Extended custom effect (wave, meteor, etc.)
+            if not bulb.supports_extended_custom_effects:
+                raise ValueError(
+                    f"Device {bulb.model} (model_num=0x{bulb.model_num:02X}) "
+                    "does not support extended custom effects. "
+                    "Use jump, gradual, or strobe for this device."
+                )
+            pattern_id = custom["pattern_id"]
+            speed = custom["speed"]
+            density = custom["density"]
+            colors = custom["colors"]
+            direction = custom["direction"]
+            option = custom["option"]
+
+            # Get pattern name for display
+            try:
+                pattern_name = (
+                    ExtendedCustomEffectPattern(pattern_id)
+                    .name.lower()
+                    .replace("_", " ")
+                )
+            except ValueError:
+                pattern_name = f"pattern {pattern_id}"
+            dir_name = (
+                "L->R"
+                if direction == ExtendedCustomEffectDirection.LEFT_TO_RIGHT.value
+                else "R->L"
+            )
+            buf_in(
+                f"Setting extended effect: {pattern_name}, "
+                f"Speed={speed}%, Density={density}%, Direction={dir_name}, "
+                f"Colors={colors}"
+            )
+            await bulb.async_set_extended_custom_effect(
+                pattern_id, colors, speed, density, direction, option
+            )
+
+        elif mode == "segments":
+            # Custom segment colors
+            if not bulb.supports_extended_custom_effects:
+                raise ValueError(
+                    f"Device {bulb.model} (model_num=0x{bulb.model_num:02X}) "
+                    "does not support custom segment colors. "
+                    "This feature is only available on 0xB6 devices."
+                )
+            buf_in(f"Setting custom segment colors: {len(custom['colors'])} segments")
+            await bulb.async_set_custom_segment_colors(custom["colors"])
 
     elif options.preset is not None:
         buf_in(
@@ -806,14 +1181,29 @@ async def _async_run_commands(
         buf_in("{} [{}] {} ({})".format(info["id"], info["ipaddr"], bulb, bulb.model))
 
     if options.settimer:
-        empty_timers: list[LedTimer] = []
-        timers = await bulb.async_get_timers() or empty_timers
+        # Check if device uses extended timer format (0xB6)
+        is_extended = isinstance(bulb._protocol, ProtocolLEDENETExtendedCustom)
         num = int(options.settimer[0])
-        buf_in(f"New Timer ---- #{num}: {options.new_timer}")
-        if options.new_timer.isExpired():
-            buf_in("[timer is already expired, will be deactivated]")
-        timers[num - 1] = options.new_timer
-        await bulb.async_set_timers(timers)
+
+        if is_extended:
+            # Create a minimal parser for error handling
+            temp_parser = OptionParser()
+            ext_timer = processSetTimerArgsExtended(temp_parser, options.settimer)
+            buf_in(f"New Timer ---- #{num}: {ext_timer}")
+            await bulb.async_set_timer(ext_timer)
+        else:
+            temp_parser = OptionParser()
+            std_timer = processSetTimerArgs(temp_parser, options.settimer)
+            buf_in(f"New Timer ---- #{num}: {std_timer}")
+            if std_timer.isExpired():
+                buf_in("[timer is already expired, will be deactivated]")
+            timers_result = await bulb.async_get_timers()
+            timers_list = cast("list[LedTimer]", timers_result) if timers_result else []
+            if len(timers_list) < num:
+                # Extend list if needed
+                timers_list.extend([LedTimer() for _ in range(num - len(timers_list))])
+            timers_list[num - 1] = std_timer
+            await bulb.async_set_timers(timers_list)
 
     if options.showtimers:
         show_timers = await bulb.async_get_timers()

--- a/flux_led/fluxled.py
+++ b/flux_led/fluxled.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+import re
 import sys
 from optparse import OptionGroup, OptionParser, Values
 from typing import Any, cast
@@ -57,6 +58,9 @@ from .const import (
     TIMER_ACTION_ON,
     ExtendedCustomEffectDirection,
     ExtendedCustomEffectPattern,
+    ScribbleBlinkMode,
+    ScribbleEffect,
+    ScribbleLED,
 )
 from .pattern import PresetPattern
 from .protocol import ProtocolLEDENETExtendedCustom
@@ -124,6 +128,9 @@ Set extended effect with density, direction, and color change options:
 
 Set custom segment colors (0xB6 devices) - set each segment individually:
     %prog% 192.168.1.100 -C segments 0 "red green blue off off red green blue"
+
+Set per-LED scribble colors (0xB6 devices) - specify each LED individually:
+    %prog% 192.168.1.100 -C scribble static "10xred 70xoff"
 
 Sync all bulb's clocks with this computer's:
     %prog% -sS --setclock
@@ -515,6 +522,165 @@ def processSetTimerArgsExtended(
     raise SystemExit(1)  # For type checker
 
 
+_SCRIBBLE_EFFECT_NAMES: dict[str, ScribbleEffect] = {
+    "static": ScribbleEffect.STATIC,
+    "flowing": ScribbleEffect.FLOWING,
+    "twinkling": ScribbleEffect.TWINKLING_STARS,
+    "stars_wink": ScribbleEffect.STARS_WINK,
+    "accumulate": ScribbleEffect.ACCUMULATE,
+}
+
+_SCRIBBLE_BLINK_NAMES: dict[str, ScribbleBlinkMode] = {
+    "none": ScribbleBlinkMode.NONE,
+    "slow": ScribbleBlinkMode.SLOW,
+    "fast": ScribbleBlinkMode.FAST,
+}
+
+_RUN_LENGTH_RE = re.compile(r"^(?:(\d+)x)?(.+)$")
+_WHITE_LEVEL_RE = re.compile(r"^w(\d+)$")
+
+
+def _parse_scribble_led_token(
+    token: str,
+    parser: OptionParser,
+    blink_mode: ScribbleBlinkMode,
+    blink_speed: int,
+) -> ScribbleLED:
+    """Parse a single LED value token (without run-length prefix) into a ScribbleLED."""
+    token_lower = token.lower()
+    if token_lower == "off":
+        return ScribbleLED(rgb=None, white=None, blink_mode=blink_mode, blink_speed=blink_speed)
+    # White-level token: 'w' followed by DIGITS ONLY (e.g. w50). A token like
+    # 'white' or 'wheat' is a color name, so it falls through to the color parser.
+    white_match = _WHITE_LEVEL_RE.match(token_lower)
+    if white_match:
+        level = int(white_match.group(1))
+        return ScribbleLED(rgb=None, white=level, blink_mode=blink_mode, blink_speed=blink_speed)
+    # Color token
+    c = utils.color_object_to_tuple(token)
+    if c is None or len(c) < 3:
+        parser.error(
+            f"Invalid color token '{token}'. Use a color name, hex value, or r,g,b triple."
+        )
+        raise SystemExit(1)
+    return ScribbleLED(rgb=(c[0], c[1], c[2]), white=None, blink_mode=blink_mode, blink_speed=blink_speed)
+
+
+def _process_scribble_args(
+    parser: OptionParser,
+    args: Any,
+) -> dict[str, Any] | None:
+    """Parse scribble-mode args: ('scribble', <effect>, '<per-led-spec>')."""
+    effect_name = args[1].lower() if len(args) > 1 else "static"
+    if effect_name not in _SCRIBBLE_EFFECT_NAMES:
+        parser.error(
+            f"Unknown scribble effect '{effect_name}'. "
+            f"Valid: {', '.join(_SCRIBBLE_EFFECT_NAMES)}."
+        )
+        return None
+    effect = _SCRIBBLE_EFFECT_NAMES[effect_name]
+
+    spec_str = args[2].strip() if len(args) > 2 else ""
+
+    # Defaults for optional key=value tokens
+    density = 80
+    speed = 100
+    direction = ExtendedCustomEffectDirection.LEFT_TO_RIGHT
+    blink_mode = ScribbleBlinkMode.NONE
+    blink_speed = 100
+
+    # Split spec on whitespace; separate LED tokens from key=value tokens
+    all_tokens = spec_str.split()
+    led_tokens: list[str] = []
+    for tok in all_tokens:
+        if "=" in tok:
+            key, _, val = tok.partition("=")
+            key = key.lower().strip()
+            val = val.strip()
+            if key == "density":
+                try:
+                    density = int(val)
+                except ValueError:
+                    parser.error(f"Invalid density value '{val}'. Must be an integer.")
+                    return None
+            elif key == "speed":
+                try:
+                    speed = int(val)
+                except ValueError:
+                    parser.error(f"Invalid speed value '{val}'. Must be an integer.")
+                    return None
+            elif key == "dir":
+                if val.lower() in ("l2r", "left", "ltr"):
+                    direction = ExtendedCustomEffectDirection.LEFT_TO_RIGHT
+                elif val.lower() in ("r2l", "right", "rtl"):
+                    direction = ExtendedCustomEffectDirection.RIGHT_TO_LEFT
+                else:
+                    parser.error(f"Invalid dir value '{val}'. Use l2r or r2l.")
+                    return None
+            elif key == "blink":
+                bl = val.lower()
+                if bl not in _SCRIBBLE_BLINK_NAMES:
+                    parser.error(
+                        f"Invalid blink value '{val}'. Use none, slow, or fast."
+                    )
+                    return None
+                blink_mode = _SCRIBBLE_BLINK_NAMES[bl]
+            elif key == "blinkspeed":
+                try:
+                    blink_speed = int(val)
+                except ValueError:
+                    parser.error(f"Invalid blinkspeed value '{val}'. Must be an integer.")
+                    return None
+            else:
+                parser.error(f"Unknown scribble option '{key}'.")
+                return None
+        else:
+            led_tokens.append(tok)
+
+    # Expand run-length tokens into ScribbleLED list
+    leds: list[ScribbleLED] = []
+    for tok in led_tokens:
+        m = _RUN_LENGTH_RE.match(tok)
+        if not m:
+            parser.error(f"Malformed LED token '{tok}'.")
+            return None
+        count_str, value_part = m.group(1), m.group(2)
+        count = int(count_str) if count_str else 1
+        led = _parse_scribble_led_token(value_part, parser, blink_mode, blink_speed)
+        leds.extend([led] * count)
+
+    if not leds:
+        parser.error("At least one LED entry is required for scribble mode.")
+        return None
+
+    return {
+        "mode": "scribble",
+        "effect": effect.value,
+        "leds": leds,
+        "direction": direction.value,
+        "density": density,
+        "speed": speed,
+    }
+
+
+def _reconcile_scribble_led_count(
+    leds: list[ScribbleLED],
+    device_count: int | None,
+) -> list[ScribbleLED]:
+    """Reconcile a parsed LED list against the device's configured LED count.
+
+    If device_count is None (state unknown), return leds unchanged. Otherwise
+    pad the tail with off-LEDs or truncate so the result is exactly
+    device_count entries.
+    """
+    if device_count is None or len(leds) == device_count:
+        return leds
+    if len(leds) > device_count:
+        return leds[:device_count]
+    padding = [ScribbleLED(rgb=None, white=None)] * (device_count - len(leds))
+    return leds + padding
+
+
 def processCustomArgs(
     parser: OptionParser,
     args: Any,
@@ -542,6 +708,12 @@ def processCustomArgs(
         extended_pattern_names[p.name.lower()] = p.value
 
     pattern_type = args[0].lower()
+
+    # Check if this is "scribble" mode (must come before speed = int(args[1])
+    # because args[1] is an effect name, not a numeric speed)
+    if pattern_type == "scribble":
+        return _process_scribble_args(parser, args)
+
     speed = int(args[1])
 
     # Check if this is a standard pattern
@@ -808,8 +980,9 @@ def parseArgs() -> tuple[Values, Any]:
         nargs=3,
         help="Set custom pattern mode. "
         + "TYPE: jump, gradual, strobe (standard), or extended pattern names "
-        + "(wave, meteor, breathe, etc. for 0xB6 devices), or 'segments' for static colors. "
-        + "SPEED is percent (0-100). "
+        + "(wave, meteor, breathe, etc. for 0xB6 devices), or 'segments' for static colors, "
+        + "or 'scribble' for per-LED colors (0xB6 devices). "
+        + "SPEED is percent (0-100) (for scribble, use the effect name instead). "
         + "COLORLIST is a space-separated list of color names, hex values, or RGB triples. "
         + "Use --density, --direction, --colorchange for extended pattern options.",
     )
@@ -931,6 +1104,10 @@ def parseArgs() -> tuple[Values, Any]:
             print(f"  {p.name.lower().replace('_', ' '):<20} (ID: {p.value})")
         print("\nSegment colors (-C segments, 0xB6 devices only):")
         print("  segments - Set individual segment colors (up to 20)")
+        print("\nPer-LED scribble (-C scribble, 0xB6 devices only):")
+        print("  scribble <effect> \"<per-led-spec>\"  - Set per-LED colors/blink")
+        print("  Effects: static, flowing, twinkling, stars_wink, accumulate")
+        print("  Example: -C scribble static \"10xred 70xoff\"")
         sys.exit(0)
 
     if options.listcolors:
@@ -1163,6 +1340,46 @@ async def _async_run_commands(
                 )
             buf_in(f"Setting custom segment colors: {len(custom['colors'])} segments")
             await bulb.async_set_custom_segment_colors(custom["colors"])
+
+        elif mode == "scribble":
+            # Per-LED scribble configuration
+            if not bulb.supports_scribble:
+                buf_in(
+                    f"{bulb.model} does not support the scribble (per-LED) feature."
+                )
+            else:
+                leds = custom["leds"]
+                effect = ScribbleEffect(custom["effect"])
+                direction = ExtendedCustomEffectDirection(custom["direction"])
+                density = custom["density"]
+                speed = custom["speed"]
+                # Reconcile parsed LED count with the device's configured count:
+                # pad the tail with off-LEDs or truncate so the upload is exactly
+                # the device's LED count (avoids the API's hard count check).
+                device_count = bulb.led_count
+                if device_count is not None and len(leds) != device_count:
+                    buf_in(
+                        f"Warning: {len(leds)} LED entries provided but device has "
+                        f"{device_count} LEDs; "
+                        + (
+                            "padding tail with off."
+                            if len(leds) < device_count
+                            else "truncating."
+                        )
+                    )
+                    leds = _reconcile_scribble_led_count(leds, device_count)
+                buf_in(
+                    f"Setting scribble: {len(leds)} LEDs, "
+                    f"effect={effect.name.lower()}, "
+                    f"speed={speed}, density={density}"
+                )
+                await bulb.async_set_scribble(
+                    leds,
+                    effect=effect,
+                    direction=direction,
+                    density=density,
+                    speed=speed,
+                )
 
     elif options.preset is not None:
         buf_in(

--- a/flux_led/fluxled.py
+++ b/flux_led/fluxled.py
@@ -546,39 +546,102 @@ def _parse_scribble_led_token(
     blink_mode: ScribbleBlinkMode,
     blink_speed: int,
 ) -> ScribbleLED:
-    """Parse a single LED value token (without run-length prefix) into a ScribbleLED."""
-    token_lower = token.lower()
+    """Parse a single LED value token into a ScribbleLED.
+
+    Accepts an optional per-token blink suffix using '/' as separator:
+    ``<value>[/<blinkmode>[/<blinkspeed>]]``
+
+    ``<value>`` is a color name/hex/r,g,b, a white-level ``w<level>``, or
+    ``off``.  ``<blinkmode>`` is ``none|slow|fast``; ``<blinkspeed>`` is
+    0-100.  A per-token blink suffix overrides the caller-supplied global
+    blink_mode / blink_speed defaults.
+    """
+    # Split off optional /blinkmode[/blinkspeed] suffix.
+    # '/' cannot appear in color names (hex uses only hex digits; r,g,b uses
+    # commas; color names are plain words), so splitting on '/' is unambiguous.
+    parts = token.split("/")
+    value_part = parts[0]
+    if len(parts) > 1:
+        # Per-token blink override present
+        blink_part = parts[1].lower()
+        if blink_part not in _SCRIBBLE_BLINK_NAMES:
+            parser.error(
+                f"Invalid blink mode '{parts[1]}' in token '{token}'. "
+                f"Use none, slow, or fast."
+            )
+            raise SystemExit(1)
+        blink_mode = _SCRIBBLE_BLINK_NAMES[blink_part]
+        if len(parts) > 2:
+            try:
+                blink_speed = int(parts[2])
+            except ValueError:
+                parser.error(
+                    f"Invalid blink speed '{parts[2]}' in token '{token}'. "
+                    f"Must be an integer."
+                )
+                raise SystemExit(1)
+        if len(parts) > 3:
+            parser.error(f"Too many '/' separators in token '{token}'.")
+            raise SystemExit(1)
+
+    token_lower = value_part.lower()
     if token_lower == "off":
-        return ScribbleLED(rgb=None, white=None, blink_mode=blink_mode, blink_speed=blink_speed)
+        return ScribbleLED(
+            rgb=None, white=None, blink_mode=blink_mode, blink_speed=blink_speed
+        )
     # White-level token: 'w' followed by DIGITS ONLY (e.g. w50). A token like
     # 'white' or 'wheat' is a color name, so it falls through to the color parser.
     white_match = _WHITE_LEVEL_RE.match(token_lower)
     if white_match:
         level = int(white_match.group(1))
-        return ScribbleLED(rgb=None, white=level, blink_mode=blink_mode, blink_speed=blink_speed)
+        return ScribbleLED(
+            rgb=None, white=level, blink_mode=blink_mode, blink_speed=blink_speed
+        )
     # Color token
-    c = utils.color_object_to_tuple(token)
+    c = utils.color_object_to_tuple(value_part)
     if c is None or len(c) < 3:
         parser.error(
-            f"Invalid color token '{token}'. Use a color name, hex value, or r,g,b triple."
+            f"Invalid color token '{value_part}'. Use a color name, hex value, or r,g,b triple."
         )
         raise SystemExit(1)
-    return ScribbleLED(rgb=(c[0], c[1], c[2]), white=None, blink_mode=blink_mode, blink_speed=blink_speed)
+    return ScribbleLED(
+        rgb=(c[0], c[1], c[2]),
+        white=None,
+        blink_mode=blink_mode,
+        blink_speed=blink_speed,
+    )
 
 
 def _process_scribble_args(
     parser: OptionParser,
     args: Any,
 ) -> dict[str, Any] | None:
-    """Parse scribble-mode args: ('scribble', <effect>, '<per-led-spec>')."""
+    """Parse scribble-mode args: ('scribble', <effect>, '<per-led-spec>').
+
+    ``<effect>`` may be a named effect (static/flowing/twinkling/stars_wink/
+    accumulate) OR a raw integer 0-8.
+    """
     effect_name = args[1].lower() if len(args) > 1 else "static"
-    if effect_name not in _SCRIBBLE_EFFECT_NAMES:
-        parser.error(
-            f"Unknown scribble effect '{effect_name}'. "
-            f"Valid: {', '.join(_SCRIBBLE_EFFECT_NAMES)}."
-        )
-        return None
-    effect = _SCRIBBLE_EFFECT_NAMES[effect_name]
+    if effect_name in _SCRIBBLE_EFFECT_NAMES:
+        effect_id: int = _SCRIBBLE_EFFECT_NAMES[effect_name].value
+    else:
+        # Try numeric id
+        try:
+            effect_id = int(effect_name)
+        except ValueError:
+            parser.error(
+                f"Unknown scribble effect '{effect_name}'. "
+                f"Valid names: {', '.join(_SCRIBBLE_EFFECT_NAMES)}; "
+                f"or a number 0-8."
+            )
+            return None
+        if not 0 <= effect_id <= 8:
+            parser.error(
+                f"Scribble effect id {effect_id} out of range. "
+                f"Valid names: {', '.join(_SCRIBBLE_EFFECT_NAMES)}; "
+                f"or a number 0-8."
+            )
+            return None
 
     spec_str = args[2].strip() if len(args) > 2 else ""
 
@@ -588,6 +651,7 @@ def _process_scribble_args(
     direction = ExtendedCustomEffectDirection.LEFT_TO_RIGHT
     blink_mode = ScribbleBlinkMode.NONE
     blink_speed = 100
+    enter_mode = True
 
     # Split spec on whitespace; separate LED tokens from key=value tokens
     all_tokens = spec_str.split()
@@ -629,7 +693,17 @@ def _process_scribble_args(
                 try:
                     blink_speed = int(val)
                 except ValueError:
-                    parser.error(f"Invalid blinkspeed value '{val}'. Must be an integer.")
+                    parser.error(
+                        f"Invalid blinkspeed value '{val}'. Must be an integer."
+                    )
+                    return None
+            elif key == "enter":
+                if val.lower() == "true":
+                    enter_mode = True
+                elif val.lower() == "false":
+                    enter_mode = False
+                else:
+                    parser.error(f"Invalid enter value '{val}'. Use true or false.")
                     return None
             else:
                 parser.error(f"Unknown scribble option '{key}'.")
@@ -655,11 +729,12 @@ def _process_scribble_args(
 
     return {
         "mode": "scribble",
-        "effect": effect.value,
+        "effect": effect_id,
         "leds": leds,
         "direction": direction.value,
         "density": density,
         "speed": speed,
+        "enter_mode": enter_mode,
     }
 
 
@@ -687,6 +762,7 @@ def processCustomArgs(
     density: int = 50,
     direction: str = "l2r",
     colorchange: bool = False,
+    variant: int | None = None,
 ) -> dict[str, Any] | None:
     """Process custom pattern arguments.
 
@@ -816,8 +892,14 @@ def processCustomArgs(
             parser.error(f"Invalid direction: {direction}. Use l2r or r2l")
             return None
 
-        # Option value
-        option_value = 0x01 if colorchange else 0x00
+        # Option value: --variant takes precedence; fall back to --colorchange.
+        if variant is not None:
+            if not 0 <= variant <= 2:
+                parser.error(f"Invalid --variant {variant}. Must be 0, 1, or 2.")
+                return None
+            option_value = variant
+        else:
+            option_value = 0x01 if colorchange else 0x00
 
         return {
             "mode": "extended",
@@ -982,9 +1064,9 @@ def parseArgs() -> tuple[Values, Any]:
         + "TYPE: jump, gradual, strobe (standard), or extended pattern names "
         + "(wave, meteor, breathe, etc. for 0xB6 devices), or 'segments' for static colors, "
         + "or 'scribble' for per-LED colors (0xB6 devices). "
-        + "SPEED is percent (0-100) (for scribble, use the effect name instead). "
+        + "SPEED is percent (0-100) (for scribble, use the effect name or 0-8 id instead). "
         + "COLORLIST is a space-separated list of color names, hex values, or RGB triples. "
-        + "Use --density, --direction, --colorchange for extended pattern options.",
+        + "Use --density, --direction, --colorchange, --variant 0|1|2 for extended pattern options.",
     )
     parser.add_option_group(mode_group)
 
@@ -1008,7 +1090,16 @@ def parseArgs() -> tuple[Values, Any]:
         action="store_true",
         dest="colorchange",
         default=False,
-        help="Enable color change option for extended effect",
+        help="Enable color change option for extended effect (equivalent to --variant 1)",
+    )
+    other_group.add_option(
+        "--variant",
+        dest="variant",
+        default=None,
+        type="int",
+        metavar="VARIANT",
+        help="Extended effect option variant: 0, 1, or 2 (overrides --colorchange). "
+        "Use with -C <extended-pattern> SPEED COLORLIST.",
     )
 
     parser.add_option(
@@ -1105,9 +1196,9 @@ def parseArgs() -> tuple[Values, Any]:
         print("\nSegment colors (-C segments, 0xB6 devices only):")
         print("  segments - Set individual segment colors (up to 20)")
         print("\nPer-LED scribble (-C scribble, 0xB6 devices only):")
-        print("  scribble <effect> \"<per-led-spec>\"  - Set per-LED colors/blink")
+        print('  scribble <effect> "<per-led-spec>"  - Set per-LED colors/blink')
         print("  Effects: static, flowing, twinkling, stars_wink, accumulate")
-        print("  Example: -C scribble static \"10xred 70xoff\"")
+        print('  Example: -C scribble static "10xred 70xoff"')
         sys.exit(0)
 
     if options.listcolors:
@@ -1148,6 +1239,7 @@ def parseArgs() -> tuple[Values, Any]:
             density=options.density,
             direction=options.direction,
             colorchange=options.colorchange,
+            variant=options.variant,
         )
 
     if options.color:
@@ -1344,15 +1436,16 @@ async def _async_run_commands(
         elif mode == "scribble":
             # Per-LED scribble configuration
             if not bulb.supports_scribble:
-                buf_in(
-                    f"{bulb.model} does not support the scribble (per-LED) feature."
-                )
+                buf_in(f"{bulb.model} does not support the scribble (per-LED) feature.")
             else:
                 leds = custom["leds"]
-                effect = ScribbleEffect(custom["effect"])
+                # Pass the raw int effect id; the API accepts ScribbleEffect|int
+                # so unnamed ids (3, 4, 6, 7) work without raising ValueError.
+                effect_id_raw: int = custom["effect"]
                 direction = ExtendedCustomEffectDirection(custom["direction"])
                 density = custom["density"]
                 speed = custom["speed"]
+                scribble_enter_mode: bool = custom.get("enter_mode", True)
                 # Reconcile parsed LED count with the device's configured count:
                 # pad the tail with off-LEDs or truncate so the upload is exactly
                 # the device's LED count (avoids the API's hard count check).
@@ -1368,17 +1461,23 @@ async def _async_run_commands(
                         )
                     )
                     leds = _reconcile_scribble_led_count(leds, device_count)
+                # Build display name for the effect id
+                try:
+                    effect_display = ScribbleEffect(effect_id_raw).name.lower()
+                except ValueError:
+                    effect_display = str(effect_id_raw)
                 buf_in(
                     f"Setting scribble: {len(leds)} LEDs, "
-                    f"effect={effect.name.lower()}, "
+                    f"effect={effect_display}, "
                     f"speed={speed}, density={density}"
                 )
                 await bulb.async_set_scribble(
                     leds,
-                    effect=effect,
+                    effect=effect_id_raw,
                     direction=direction,
                     density=density,
                     speed=speed,
+                    enter_mode=scribble_enter_mode,
                 )
 
     elif options.preset is not None:

--- a/flux_led/models_db.py
+++ b/flux_led/models_db.py
@@ -47,6 +47,7 @@ from .protocol import (
     PROTOCOL_LEDENET_ADDRESSABLE_CHRISTMAS,
     PROTOCOL_LEDENET_CCT,
     PROTOCOL_LEDENET_CCT_WRAPPED,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM,
     PROTOCOL_LEDENET_ORIGINAL,
     PROTOCOL_LEDENET_ORIGINAL_CCT,
     PROTOCOL_LEDENET_SOCKET,
@@ -1310,12 +1311,11 @@ MODELS = [
         model_num=0xB6,
         models=["AK001-ZJ21413"],
         description="Surplife Outdoor Permanent Lighting",
-        # This device ONLY responds with the extended state format (0xEA 0x81),
-        # which PROTOCOL_LEDENET_25BYTE already parses, so reusing it gives basic
-        # on/off, brightness and color. A dedicated protocol class with full
-        # custom-effect/timer support is added in a follow-up.
+        # This device ONLY responds with the extended state format (0xEA 0x81).
+        # It uses the dedicated ProtocolLEDENETExtendedCustom protocol, which adds
+        # the custom-effect, segment-color and timer support specific to it.
         always_writes_white_and_colors=False,
-        protocols=[MinVersionProtocol(0, PROTOCOL_LEDENET_25BYTE)],
+        protocols=[MinVersionProtocol(0, PROTOCOL_LEDENET_EXTENDED_CUSTOM)],
         # Single white LED (not separate warm/cool), so use RGB_W not RGB_CCT
         mode_to_color_mode={0x01: COLOR_MODES_RGB_W, 0x17: COLOR_MODES_RGB_W},
         color_modes=COLOR_MODES_RGB_W,

--- a/flux_led/pattern.py
+++ b/flux_led/pattern.py
@@ -201,6 +201,40 @@ ASSESSABLE_MULTI_COLOR_NAME_ID = {
     v: k for k, v in ASSESSABLE_MULTI_COLOR_ID_NAME.items()
 }
 
+# Extended custom effect pattern names for 0xB6 (Surplife) devices
+# These map to ExtendedCustomEffectPattern enum values
+EXTENDED_CUSTOM_EFFECT_ID_NAME = {
+    0x00: "Segments",  # Custom segment colors mode
+    0x01: "Wave",
+    0x02: "Meteor",
+    0x03: "Streamer",
+    0x04: "Building Blocks",
+    0x05: "Flowing Water",
+    0x06: "Chase",
+    0x07: "Horse Racing",
+    0x08: "Cycle",
+    0x09: "Breathe",
+    0x0A: "Jump",
+    0x0B: "Strobe",
+    0x0C: "Twinkling Stars",
+    0x0D: "Stars Wink",
+    0x0E: "Warning",
+    0x0F: "Collision",
+    0x10: "Fireworks",
+    0x11: "Comet",
+    0x12: "Gradient Meteor",
+    0x13: "Volcano",
+    0x14: "Superluminal",
+    0x15: "Rainbow Bridge",
+    0x16: "Gradient Overlay",
+    0x65: "Static Gradient",
+    0x66: "Static Fill",
+    0x6E: "Solid Color",  # Mode when solid color is set
+}
+EXTENDED_CUSTOM_EFFECT_NAME_ID = {
+    v: k for k, v in EXTENDED_CUSTOM_EFFECT_ID_NAME.items()
+}
+
 ORIGINAL_ADDRESSABLE_EFFECT_ID_NAME = {
     1: "Circulate all modes",
     2: "7 colors change gradually",

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -97,6 +97,7 @@ PROTOCOL_LEDENET_CCT = "LEDENET_CCT"
 PROTOCOL_LEDENET_CCT_WRAPPED = "LEDENET_CCT_WRAPPED"
 PROTOCOL_LEDENET_ADDRESSABLE_CHRISTMAS = "LEDENET_CHRISTMAS"
 PROTOCOL_LEDENET_25BYTE = "LEDENET_25_BYTE"
+PROTOCOL_LEDENET_EXTENDED_CUSTOM = "LEDENET_EXTENDED_CUSTOM"
 
 TRANSITION_BYTES = {
     TRANSITION_JUMP: 0x3B,
@@ -109,6 +110,7 @@ LEDNET_MUSIC_MODE_RESPONSE_LEN = 13  # 72 01 26 01 00 00 00 00 00 00 64 64 62
 LEDENET_POWER_RESTORE_RESPONSE_LEN = 7
 LEDENET_ORIGINAL_STATE_RESPONSE_LEN = 11
 LEDENET_STATE_RESPONSE_LEN = 14
+LEDENET_EXTENDED_STATE_RESPONSE_LEN = 21
 LEDENET_POWER_RESPONSE_LEN = 4
 LEDENET_ADDRESSABLE_STATE_RESPONSE_LEN = 25
 LEDENET_A1_DEVICE_CONFIG_RESPONSE_LEN = 12
@@ -1599,6 +1601,107 @@ class ProtocolLEDENET25Byte(ProtocolLEDENET9Byte):
                 version=0x02,
             )
         ]
+
+
+class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
+    """Protocol for the 0xB6 Surplife device (extended state + custom effects).
+
+    This device only ever responds with the extended state format (0xEA 0x81)
+    and uses an HSV+W color format. It reuses ProtocolLEDENET25Byte for the
+    standard command set; dedicated custom-effect and timer support is added in
+    follow-up changes.
+    """
+
+    @property
+    def name(self) -> str:
+        """The name of the protocol."""
+        return PROTOCOL_LEDENET_EXTENDED_CUSTOM
+
+    @property
+    def state_response_length(self) -> int:
+        """The length of the query response (extended state, 21 bytes)."""
+        return LEDENET_EXTENDED_STATE_RESPONSE_LEN
+
+    def is_valid_state_response(self, raw_state: bytes) -> bool:
+        """Check if a state response is valid.
+
+        This protocol ONLY accepts the extended state format (0xEA 0x81).
+        """
+        return self.is_valid_extended_state_response(raw_state)
+
+    def named_raw_state(self, raw_state: bytes) -> LEDENETRawState:
+        """Convert raw_state to a namedtuple.
+
+        The extended state format (0xEA 0x81) is converted to the standard
+        14-byte layout first so the synchronous state path can parse it.
+        """
+        if self.is_valid_extended_state_response(raw_state):
+            raw_state = self.extended_state_to_state(raw_state)
+        return LEDENETRawState(*raw_state)
+
+    def extended_state_to_state(self, raw_state: bytes) -> bytes:
+        """Convert extended state to standard state format.
+
+        For this protocol, the extended state mode (position 8) always contains
+        the custom effect pattern ID when preset_pattern is 0x25, and a white
+        brightness of 0 (or out-of-range temp) means the white LED is off.
+        """
+        if len(raw_state) < 20:
+            return b""
+
+        model_num = raw_state[4]
+        version_number = raw_state[5]
+        power_state = raw_state[6]
+        preset_pattern = raw_state[7]
+        speed = raw_state[9]
+
+        hue = raw_state[11]
+        saturation = raw_state[12]
+        value = raw_state[13]
+
+        white_temp = raw_state[14]
+        white_brightness = raw_state[15]
+
+        if white_temp > 100 or white_brightness == 0:
+            cool_white = 0
+            warm_white = 0
+        else:
+            levels = scaled_color_temp_to_white_levels(white_temp, white_brightness)
+            cool_white = levels.cool_white
+            warm_white = levels.warm_white
+
+        # Convert HSV to RGB
+        h = (hue * 2) / 360
+        s = saturation / 100
+        v = value / 100
+        r_f, g_f, b_f = colorsys.hsv_to_rgb(h, s, v)
+        red = min(int(max(0, r_f) * 255), 255)
+        green = min(int(max(0, g_f) * 255), 255)
+        blue = min(int(max(0, b_f) * 255), 255)
+
+        # mode carries the effect pattern ID in custom pattern mode (0x25)
+        mode = raw_state[8] if preset_pattern == 0x25 else 0
+        color_mode = 0
+        check_sum = 0
+
+        return bytes(
+            (
+                raw_state[1],  # Head (0x81)
+                model_num,
+                power_state,
+                preset_pattern,
+                mode,
+                speed,
+                red,
+                green,
+                blue,
+                warm_white,
+                version_number,
+                cool_white,
+                color_mode,
+                check_sum,
+            )
+        )
 
 
 class ProtocolLEDENETAddressableBase(ProtocolLEDENET9Byte):

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -7,6 +7,7 @@ import contextlib
 import datetime
 import logging
 from abc import abstractmethod
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from typing import NamedTuple
@@ -1709,6 +1710,7 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
         if not self.is_valid_extended_state_response(raw_state):
             return None
         return raw_state[LEDENET_EXTENDED_STATE_LED_COUNT_POS]
+
     def _rgb_to_hsv_bytes_rgbw(
         self, r: int, g: int, b: int, white: int = 0
     ) -> list[int]:
@@ -1926,6 +1928,107 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
             else:
                 msg.extend([0x00, 0x00, 0x00, 0x00, 0x00])  # Off
 
+        return self.construct_wrapped_message(
+            msg, inner_pre_constructed=True, version=0x02
+        )
+
+    @staticmethod
+    def _scribble_bitmap(led_indices: Iterable[int], num_leds: int) -> bytearray:
+        """Build a ceil(num_leds/8)-byte MSB-first bitmap.
+
+        LED i -> byte i//8, bit 7-(i%8). Bit set = 'apply this command to LED i'.
+        Trailing pad bits in the last byte are 0 (e.g. N=100 -> 13 bytes, last
+        byte 0xf0; N=80 -> 10 bytes, no pad).
+        """
+        nbytes = (num_leds + 7) // 8
+        bitmap = bytearray(nbytes)
+        for i in led_indices:
+            if not 0 <= i < num_leds:
+                raise ValueError(f"LED index {i} out of range for {num_leds} LEDs")
+            bitmap[i // 8] |= 0x80 >> (i % 8)
+        return bitmap
+
+    def construct_scribble_init(self, num_leds: int) -> bytearray:
+        """Construct a scribble-mode init command (0xE1 0x23, non-rendering).
+
+        Verified on hardware: E1 23 does NOT render -- it is only a
+        non-rendering buffer / scribble-mode-init (it flips state preset to
+        0x66). Its per-LED color fields are vestigial for driving the display,
+        so this emits all-zero records. All colors render through grouped
+        E1 26 paints (see construct_scribble_paint).
+
+        Inner byte layout:
+          e1 23 | 01 00 01 50 64 00 | N | <N x 7-byte all-zero records>
+           0  1    2  3  4  5  6  7   8    9 ...
+
+        Each 7-byte record is [H/2, S, V, pad, pad, WW, bright] = all-zero
+        color/white with brightness byte 0x64 (100). inner_len = 9 + 7*N.
+        """
+        msg = bytearray([0xE1, 0x23, 0x01, 0x00, 0x01, 0x50, 0x64, 0x00, num_leds])
+        msg.extend(bytes.fromhex("00000000000064") * num_leds)
+        return self.construct_wrapped_message(
+            msg, inner_pre_constructed=True, version=0x02
+        )
+
+    def construct_scribble_paint(
+        self,
+        effect: int = 0x00,
+        direction: int = 0x01,
+        density: int = 0x50,
+        speed: int = 0x64,
+        blink_mode: int = 0x00,
+        h2: int = 0x00,
+        s: int = 0x00,
+        v: int = 0x00,
+        white: int = 0x00,
+        blink_speed: int = 0x64,
+        bitmap_leds: Iterable[int] | None = None,
+        num_leds: int = 0,
+    ) -> bytearray:
+        """Construct a scribble paint command (0xE1 0x26, the render path).
+
+        Sets and displays per-LED color / white / blink / global-effect onto
+        the subset of LEDs selected by a bitmap.
+
+        Inner byte layout:
+          e1 26 | EFFECT | DIR | DENSITY | SPEED | BLINK | H/2 | S | V | 00 | WLVL | BLINKSPD | <bitmap>
+           0  1     2       3      4         5       6      7    8   9   10    11       12        13 ...
+
+        13-byte header then ceil(num_leds/8)-byte bitmap. If bitmap_leds is
+        None, all LEDs (0..num_leds-1) are selected.
+
+        Color vs white are mutually exclusive (caller's responsibility):
+        color mode -> v set, white=0; white mode -> white set, v=0.
+
+        All arguments are plain ints; enum->value conversion is done in the
+        generate/API layer where the type is a known enum (mypy-clean).
+        """
+        density = max(0, min(100, density))
+        speed = max(0, min(100, speed))
+        blink_speed = max(0, min(100, blink_speed))
+        s = max(0, min(100, s))
+        v = max(0, min(100, v))
+        white = max(0, min(100, white))
+        h2 = max(0, min(180, h2))
+        msg = bytearray(
+            [
+                0xE1,
+                0x26,
+                effect,
+                direction,
+                density,
+                speed,
+                blink_mode,
+                h2,
+                s,
+                v,
+                0x00,
+                white,
+                blink_speed,
+            ]
+        )
+        indices = range(num_leds) if bitmap_leds is None else bitmap_leds
+        msg.extend(self._scribble_bitmap(indices, num_leds))
         return self.construct_wrapped_message(
             msg, inner_pre_constructed=True, version=0x02
         )

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -120,6 +120,7 @@ LEDENET_TIME_RESPONSE_LEN = 12  # 10 14 16 01 02 10 26 20 07 00 0f a9
 LEDENET_TIMERS_8BYTE_RESPONSE_LEN = 88
 LEDENET_TIMERS_9BYTE_RESPONSE_LEN = 94
 LEDENET_TIMERS_SOCKET_RESPONSE_LEN = 100
+LEDENET_EXTENDED_STATE_LED_COUNT_POS = 18  # byte index in the raw extended state buffer
 
 MSG_ORIGINAL_POWER_STATE = "original_power_state"
 MSG_ORIGINAL_STATE = "original_state"
@@ -508,11 +509,11 @@ class ProtocolBase:
     def is_valid_state_response(self, raw_state: bytes | bytearray) -> bool:
         """Check if a state response is valid."""
 
-    def is_valid_extended_state_response(self, raw_state: bytes) -> bool:
+    def is_valid_extended_state_response(self, raw_state: bytes | bytearray) -> bool:
         return False
 
     @abstractmethod
-    def extended_state_to_state(self, raw_state: bytes) -> bytes:
+    def extended_state_to_state(self, raw_state: bytes | bytearray) -> bytes:
         """Convert an extended state response to a state response."""
 
     def is_checksum_correct(self, msg: bytes | bytearray) -> bool:
@@ -1023,7 +1024,7 @@ class ProtocolLEDENET8Byte(ProtocolBase):
         """Check if a message is the start of a state response."""
         return _message_type_from_start_of_msg(data) == MSG_POWER_STATE
 
-    def is_valid_extended_state_response(self, raw_state: bytes) -> bool:
+    def is_valid_extended_state_response(self, raw_state: bytes | bytearray) -> bool:
         """Check if this is an extended state response (0xEA 0x81 format).
 
         The 0xB6 device replies only with this format, so probing must
@@ -1444,11 +1445,11 @@ class ProtocolLEDENET25Byte(ProtocolLEDENET9Byte):
         """The name of the protocol."""
         return PROTOCOL_LEDENET_25BYTE
 
-    def is_valid_extended_state_response(self, raw_state: bytes) -> bool:
+    def is_valid_extended_state_response(self, raw_state: bytes | bytearray) -> bool:
         """Check if a state response is valid."""
         return raw_state[0] == 0xEA and raw_state[1] == 0x81 and len(raw_state) >= 20
 
-    def extended_state_to_state(self, raw_state: bytes) -> bytes:
+    def extended_state_to_state(self, raw_state: bytes | bytearray) -> bytes:
         """Convert an extended state response to a state response."""
         # pos  0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19
         #     EA  81  01  10  35  0A  23  61  01  50  0F  3C  64  64  00  64  00  00  00  00
@@ -1622,14 +1623,14 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
         """The length of the query response (extended state, 21 bytes)."""
         return LEDENET_EXTENDED_STATE_RESPONSE_LEN
 
-    def is_valid_state_response(self, raw_state: bytes) -> bool:
+    def is_valid_state_response(self, raw_state: bytes | bytearray) -> bool:
         """Check if a state response is valid.
 
         This protocol ONLY accepts the extended state format (0xEA 0x81).
         """
         return self.is_valid_extended_state_response(raw_state)
 
-    def named_raw_state(self, raw_state: bytes) -> LEDENETRawState:
+    def named_raw_state(self, raw_state: bytes | bytearray) -> LEDENETRawState:
         """Convert raw_state to a namedtuple.
 
         The extended state format (0xEA 0x81) is converted to the standard
@@ -1639,7 +1640,7 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
             raw_state = self.extended_state_to_state(raw_state)
         return LEDENETRawState(*raw_state)
 
-    def extended_state_to_state(self, raw_state: bytes) -> bytes:
+    def extended_state_to_state(self, raw_state: bytes | bytearray) -> bytes:
         """Convert extended state to standard state format.
 
         For this protocol, the extended state mode (position 8) always contains
@@ -1702,6 +1703,12 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
                 check_sum,
             )
         )
+
+    def extended_state_led_count(self, raw_state: bytes) -> int | None:
+        """Return the configured LED count from an extended state response, or None."""
+        if not self.is_valid_extended_state_response(raw_state):
+            return None
+        return raw_state[LEDENET_EXTENDED_STATE_LED_COUNT_POS]
 
 
 class ProtocolLEDENETAddressableBase(ProtocolLEDENET9Byte):

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -1709,6 +1709,226 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
         if not self.is_valid_extended_state_response(raw_state):
             return None
         return raw_state[LEDENET_EXTENDED_STATE_LED_COUNT_POS]
+    def _rgb_to_hsv_bytes_rgbw(
+        self, r: int, g: int, b: int, white: int = 0
+    ) -> list[int]:
+        """Convert RGBW (0-255) to 5-byte HSVW format for extended effect commands.
+
+        Output format:
+          [H/2, S, V, 0x00, W]
+           0    1  2   3    4
+           |    |  |   |    white LED brightness (0-255)
+           |    |  |   unused (always 0x00)
+           |    |  value/brightness (0-100)
+           |    saturation (0-100)
+           hue divided by 2 (0-180)
+
+        Args:
+            r: Red component (0-255)
+            g: Green component (0-255)
+            b: Blue component (0-255)
+            white: White LED brightness (0-255)
+
+        Returns:
+            5-byte list [H/2, S, V, 0x00, W]
+        """
+        h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+        return [int(h * 180), int(s * 100), int(v * 100), 0x00, white]
+
+    def construct_levels_change(
+        self,
+        persist: int,
+        red: int | None,
+        green: int | None,
+        blue: int | None,
+        warm_white: int | None,
+        cool_white: int | None,
+        write_mode: LevelWriteMode | int,
+    ) -> list[bytearray]:
+        """Construct level change using 0xE1 0x21 STATIC_FILL command.
+
+        The parent's 0xE0 wrapped command works for RGB but not for CCT/white.
+        This override uses extended custom effect command (0xE1 0x21) with
+        STATIC_FILL pattern (0x66) which supports both RGB and white.
+
+        Inner message format (before wrapping):
+          pos  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
+              E1 21 00 64 66 00 01 32 32 00 00 00 00 00 00 01 HH SS VV 00 WW
+                        |  |  |  |  |  |                    |  |  |  |  |  |
+                        |  |  |  |  |  |                    |  |  |  |  |  white (0-255)
+                        |  |  |  |  |  |                    |  |  |  |  unused
+                        |  |  |  |  |  |                    |  |  |  value (0-100)
+                        |  |  |  |  |  |                    |  |  saturation (0-100)
+                        |  |  |  |  |  |                    |  hue/2 (0-180)
+                        |  |  |  |  |  |                    color count (1)
+                        |  |  |  |  |  reserved (6 bytes, all 0x00)
+                        |  |  |  |  speed (0x32 = 50)
+                        |  |  |  density (0x32 = 50)
+                        |  |  direction (0x01 = L->R)
+                        |  option (0x00 = default)
+                        pattern ID (0x66 = STATIC_FILL)
+
+        Note: Device has single white LED, so warm_white and cool_white
+        are combined into one brightness value.
+        """
+        # STATIC_FILL pattern ID
+        STATIC_FILL = 0x66
+
+        r = red or 0
+        g = green or 0
+        b = blue or 0
+
+        # Combine warm and cool white into single white brightness
+        # (device only has one white LED)
+        w = min((warm_white or 0) + (cool_white or 0), 255)
+
+        # Build extended custom effect command with RGBW support
+        msg = bytearray(
+            [
+                0xE1,
+                0x21,
+                0x00,  # Command type
+                0x64,  # Constant (100)
+                STATIC_FILL,  # Pattern ID
+                0x00,  # Option
+                0x01,  # Direction (L->R)
+                0x32,  # Density (50)
+                0x32,  # Speed (50)
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,  # Reserved (6 bytes)
+                0x01,  # Color count (1)
+            ]
+        )
+
+        # Add RGBW color as HSV with white in 5th byte
+        msg.extend(self._rgb_to_hsv_bytes_rgbw(r, g, b, w))
+
+        return [
+            self.construct_wrapped_message(
+                msg, inner_pre_constructed=True, version=0x02
+            )
+        ]
+
+    def _rgb_to_hsv_bytes(self, r: int, g: int, b: int) -> list[int]:
+        """Convert RGB (0-255) to 5-byte HSV format [H/2, S, V, 0, 0].
+
+        This format is used by extended commands (0xE1 0x21, 0xE1 0x22).
+        """
+        h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+        return [int(h * 180), int(s * 100), int(v * 100), 0x00, 0x00]
+
+    def construct_extended_custom_effect(
+        self,
+        pattern_id: int,
+        colors: list[tuple[int, int, int]],
+        speed: int = 50,
+        density: int = 50,
+        direction: int = 0x01,
+        option: int = 0x00,
+    ) -> bytearray:
+        """Construct an extended custom effect command.
+
+        Protocol format:
+          0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 ...
+         e1 21 00 64 PP OO DD NS SP 00 00 00 00 00 00 CC [H S V 00 00] x N
+                    |  |  |  |  |                    |  colors (5 bytes each)
+                    |  |  |  |  |                    color count
+                    |  |  |  |  speed (0-100)
+                    |  |  |  density (0-100)
+                    |  |  direction (01=L->R, 02=R->L)
+                    |  option (00=default, 01=color change)
+                    pattern_id (1-24 or 101-102)
+
+        Args:
+            pattern_id: Pattern ID 1-24 or 101-102
+            colors: List of 1-8 RGB color tuples (0-255 per channel)
+            speed: Animation speed 0-100 (default 50)
+            density: Pattern density 0-100 (default 50)
+            direction: 0x01=L->R, 0x02=R->L (default L->R)
+            option: Pattern-specific option (default 0)
+
+        Returns:
+            Wrapped command bytearray
+        """
+        # Clamp values to valid range
+        speed = max(0, min(100, speed))
+        density = max(0, min(100, density))
+
+        # Convert Enum to value if needed
+        if hasattr(pattern_id, "value"):
+            pattern_id = pattern_id.value
+        if hasattr(option, "value"):
+            option = option.value
+        if hasattr(direction, "value"):
+            direction = direction.value
+
+        # Build inner message
+        msg = bytearray(
+            [
+                0xE1,
+                0x21,
+                0x00,  # Command type
+                0x64,  # Constant (100)
+                pattern_id,
+                option,
+                direction,
+                density,
+                speed,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,  # Reserved (6 bytes)
+                len(colors),  # Color count
+            ]
+        )
+
+        # Add colors as HSV (5 bytes each)
+        for r, g, b in colors:
+            msg.extend(self._rgb_to_hsv_bytes(r, g, b))
+
+        return self.construct_wrapped_message(
+            msg, inner_pre_constructed=True, version=0x02
+        )
+
+    def construct_custom_segment_colors(
+        self,
+        segments: list[tuple[int, int, int] | None],
+    ) -> bytearray:
+        """Construct a custom segment colors command (0xE1 0x22).
+
+        Sets static HSV colors for each of 20 segments on the light strip.
+        Used by devices like AK001-ZJ21413 (model 0xB6) under the "colorful" menu.
+
+        Protocol format:
+          e1 22 00 00 00 00 14 [H/2 S V 00 00] x 20
+
+        Args:
+            segments: List of up to 20 segment colors. Each segment is either:
+                - None or (0, 0, 0) for off
+                - (R, G, B) tuple with values 0-255
+
+        Returns:
+            Wrapped command bytearray
+        """
+        # Build inner message: header + 20 segments
+        msg = bytearray([0xE1, 0x22, 0x00, 0x00, 0x00, 0x00, 0x14])
+
+        for i in range(20):
+            segment = segments[i] if i < len(segments) else None
+            if segment and segment != (0, 0, 0):
+                msg.extend(self._rgb_to_hsv_bytes(*segment))
+            else:
+                msg.extend([0x00, 0x00, 0x00, 0x00, 0x00])  # Off
+
+        return self.construct_wrapped_message(
+            msg, inner_pre_constructed=True, version=0x02
+        )
 
 
 class ProtocolLEDENETAddressableBase(ProtocolLEDENET9Byte):

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -28,7 +28,7 @@ from .const import (
     LevelWriteModeData,
     MultiColorEffects,
 )
-from .timer import LedTimer
+from .timer import LedTimer, LedTimerExtended
 from .utils import (
     scaled_color_temp_to_white_levels,
     utils,
@@ -130,6 +130,7 @@ MSG_POWER_STATE = "power_state"
 MSG_STATE = "state"
 MSG_TIME = "time"
 MSG_TIMERS = "timers"
+MSG_TIMERS_EXTENDED = "timers_extended"
 MSG_MUSIC_MODE_STATE = "music_mode_state"
 MSG_ADDRESSABLE_STATE = "addressable_state"
 MSG_DEVICE_CONFIG = "device_config"
@@ -165,6 +166,7 @@ MSG_UNIQUE_START = {
     (0x63,): MSG_A1_DEVICE_CONFIG,
     (0x72,): MSG_MUSIC_MODE_STATE,
     (0x2B,): MSG_REMOTE_CONFIG,
+    (0xE0, 0x06): MSG_TIMERS_EXTENDED,  # 0xB6 device timer response
 }
 
 MSG_LENGTHS = {
@@ -2032,6 +2034,115 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
         return self.construct_wrapped_message(
             msg, inner_pre_constructed=True, version=0x02
         )
+
+    # --- Timer Support for 0xB6 devices ---
+    # This protocol uses a different timer format than other protocols:
+    # - Query: e0 06 (wrapped)
+    # - Response: e0 06 + variable length slot data
+    # - Set: e0 05 SS f0 HH MM 00 RR ... (wrapped)
+
+    def construct_get_timers(self) -> bytearray:
+        """Construct a get timers request.
+
+        0xB6 devices use the wrapped e0 06 command for timer queries.
+        """
+        inner = bytearray([0xE0, 0x06])
+        return self.construct_wrapped_message(
+            inner, inner_pre_constructed=True, version=0x01
+        )
+
+    def construct_set_timer(self, timer: LedTimerExtended) -> bytearray:
+        """Construct a set timer command for a single timer.
+
+        0xB6 devices set timers one at a time using e0 05 SS ...
+
+        Args:
+            timer: The LedTimerExtended object to set
+
+        Returns:
+            Wrapped command bytearray
+        """
+        inner = bytearray([0xE0, 0x05, timer.slot])
+        inner.extend(timer.to_bytes())
+        return self.construct_wrapped_message(
+            inner, inner_pre_constructed=True, version=0x01
+        )
+
+    def construct_set_timers(  # type: ignore[override]
+        self, timer_list: list[LedTimerExtended]
+    ) -> list[bytearray]:
+        """Construct set timer commands for multiple timers.
+
+        0xB6 devices set timers one at a time, so this returns a list
+        of commands (one per timer).
+
+        Args:
+            timer_list: List of LedTimerExtended objects to set
+
+        Returns:
+            List of wrapped command bytearrays
+        """
+        return [self.construct_set_timer(timer) for timer in timer_list]
+
+    def is_valid_timers_response(self, msg: bytes) -> bool:
+        """Check if a message is a valid timers response.
+
+        0xB6 timer responses start with e0 06.
+        """
+        if len(msg) < 2:
+            return False
+        return msg[0] == 0xE0 and msg[1] == 0x06
+
+    def parse_get_timers(self, msg: bytes) -> list[LedTimerExtended]:  # type: ignore[override]
+        """Parse timer response into list of LedTimerExtended objects.
+
+        Response format:
+        - Empty: e0 06 (2 bytes)
+        - With timers: e0 06 [slot1] [slot2] ... [slot6]
+
+        Each slot is either:
+        - 7 bytes if empty/inactive
+        - 21 bytes if simple timer (ON/OFF/color)
+        - Variable (48+) bytes if scene timer
+        """
+        if len(msg) <= 2:
+            # Empty response or just header - no timers configured
+            return []
+
+        timers: list[LedTimerExtended] = []
+        offset = 2  # Skip e0 06 header
+
+        while offset < len(msg):
+            # Check if we have enough bytes for minimum slot (7 bytes)
+            if offset + 7 > len(msg):
+                break
+
+            timer, consumed = LedTimerExtended.from_bytes(msg, offset)
+            timers.append(timer)
+            offset += consumed
+
+        return timers
+
+    @property
+    def timer_count(self) -> int:
+        """Number of timer slots supported."""
+        return 6
+
+    def expected_timers_response_length(self, data: bytes) -> int:
+        """Calculate expected timer response length.
+
+        For 0xB6 devices, the timer response has variable length
+        based on the inner message length encoded in the wrapped message.
+        """
+        # Timer responses are wrapped, so we extract from the wrapper
+        if (
+            len(data) >= OUTER_MESSAGE_WRAPPER_START_LEN
+            and data[0] == OUTER_MESSAGE_FIRST_BYTE
+        ):
+            inner_msg_len = (data[8] << 8) + data[9]
+            return OUTER_MESSAGE_WRAPPER_START_LEN + inner_msg_len + CHECKSUM_LEN
+        # Fallback
+        return len(data)
 
 
 class ProtocolLEDENETAddressableBase(ProtocolLEDENET9Byte):

--- a/flux_led/timer.py
+++ b/flux_led/timer.py
@@ -1,9 +1,23 @@
 from __future__ import annotations
 
 import datetime
+from dataclasses import dataclass, field
 
+from .const import (
+    TIMER_ACTION_COLOR,
+    TIMER_ACTION_OFF,
+    TIMER_ACTION_ON,
+    TIMER_ACTION_SCENE_GRADIENT,
+    TIMER_ACTION_SCENE_SEGMENTS,
+    TIMER_EFFECT_GRADIENT,
+    TIMER_EFFECT_SEGMENTS,
+    ExtendedCustomEffectPattern,
+)
 from .pattern import PresetPattern
 from .utils import utils
+
+# Type alias for HSV color tuple (hue 0-180, saturation 0-100, value 0-100)
+HSVColor = tuple[int, int, int]
 
 
 class BuiltInTimer:
@@ -365,3 +379,267 @@ class LedTimer:
             txt += f"{type} (Duration:{self.duration} minutes, Brightness: {utils.byteToPercent(self.brightness_start)}% -> {utils.byteToPercent(self.brightness_end)}%)"
 
         return txt
+
+
+@dataclass
+class LedTimerExtended:
+    """Extended timer for 0xB6 devices with scene/color support.
+
+    Timer format (from packet analysis):
+    - Simple ON/OFF: 21 bytes (slot + 20 bytes data)
+    - Scene timer: variable (slot + header + effect data + Nx5 bytes colors)
+
+    Repeat mask format (different from LedTimer):
+    - bit 0: reserved (always 0 for repeat mode)
+    - bit 1-7: Mon-Sun
+    """
+
+    # Day constants (same as LedTimer)
+    Mo = 0x02
+    Tu = 0x04
+    We = 0x08
+    Th = 0x10
+    Fr = 0x20
+    Sa = 0x40
+    Su = 0x80
+    Everyday = Mo | Tu | We | Th | Fr | Sa | Su
+    Weekdays = Mo | Tu | We | Th | Fr
+    Weekend = Sa | Su
+
+    slot: int = 1
+    active: bool = True
+    hour: int = 0
+    minute: int = 0
+    repeat_mask: int = 0
+    action_type: int = TIMER_ACTION_OFF
+
+    # For color action (0xa1) - HSV tuple (hue 0-180, saturation 0-100, value 0-100)
+    color_hsv: HSVColor | None = None
+
+    # For scene actions (0x29=gradient, 0x6b=segments)
+    pattern: ExtendedCustomEffectPattern | None = None
+    speed: int = 50
+    colors: list[HSVColor] = field(default_factory=list)
+
+    @property
+    def is_scene(self) -> bool:
+        """Return True if this is a scene timer."""
+        return self.action_type in (
+            TIMER_ACTION_SCENE_GRADIENT,
+            TIMER_ACTION_SCENE_SEGMENTS,
+        )
+
+    @property
+    def is_color(self) -> bool:
+        """Return True if this is a color timer."""
+        return self.action_type == TIMER_ACTION_COLOR
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if timer turns on the device."""
+        return self.action_type in (
+            TIMER_ACTION_ON,
+            TIMER_ACTION_COLOR,
+            TIMER_ACTION_SCENE_GRADIENT,
+            TIMER_ACTION_SCENE_SEGMENTS,
+        )
+
+    @property
+    def repeat_days(self) -> list[str]:
+        """Return list of repeat day names."""
+        days = []
+        day_map = [
+            (self.Mo, "Mon"),
+            (self.Tu, "Tue"),
+            (self.We, "Wed"),
+            (self.Th, "Thu"),
+            (self.Fr, "Fri"),
+            (self.Sa, "Sat"),
+            (self.Su, "Sun"),
+        ]
+        for mask, name in day_map:
+            if self.repeat_mask & mask:
+                days.append(name)
+        return days
+
+    def to_bytes(self) -> bytes:
+        """Serialize timer to bytes for SET command (without slot number)."""
+        if not self.active:
+            return bytes(20)
+
+        if self.is_scene:
+            return self._to_bytes_scene()
+        if self.is_color:
+            return self._to_bytes_color()
+        return self._to_bytes_simple()
+
+    def _to_bytes_simple(self) -> bytes:
+        """Serialize simple ON/OFF timer."""
+        data = bytearray(20)
+        data[0] = 0xF0  # active flag
+        data[1] = self.hour
+        data[2] = self.minute
+        data[3] = 0x00  # seconds
+        data[4] = self.repeat_mask
+        data[5:10] = [0x0E, 0xE0, 0x01, 0x00, self.action_type]
+        return bytes(data)
+
+    def _to_bytes_color(self) -> bytes:
+        """Serialize color timer."""
+        data = bytearray(20)
+        data[0] = 0xF0  # active flag
+        data[1] = self.hour
+        data[2] = self.minute
+        data[3] = 0x00  # seconds
+        data[4] = self.repeat_mask
+        data[5:10] = [0x0E, 0xE0, 0x01, 0x00, TIMER_ACTION_COLOR]
+        if self.color_hsv:
+            data[10], data[11], data[12] = self.color_hsv
+        return bytes(data)
+
+    def _to_bytes_scene(self) -> bytes:
+        """Serialize scene timer."""
+        is_gradient = self.action_type == TIMER_ACTION_SCENE_GRADIENT
+        effect_type = TIMER_EFFECT_GRADIENT if is_gradient else TIMER_EFFECT_SEGMENTS
+        pattern_id = self.pattern.value if self.pattern else 0x16
+
+        data = bytearray()
+        data.extend([0xF0, self.hour, self.minute, 0x00, self.repeat_mask])
+        data.extend([self.action_type, 0xE1, effect_type])
+
+        if is_gradient:
+            # Gradient header (14 bytes + num_colors)
+            data.extend(
+                [
+                    0x00,
+                    100,
+                    pattern_id,  # sub-cmd, brightness, pattern
+                    0x00,
+                    0x01,
+                    self.speed,
+                    0x50,  # option, direction, speed, transition
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,  # padding
+                    len(self.colors),
+                ]
+            )
+        else:
+            # Segments header (4 bytes + num_colors)
+            data.extend([0x00, 0x00, 0x00, 0x00, len(self.colors)])
+
+        for h, s, v in self.colors:
+            data.extend([h, s, v, 0x00, 0x00])
+        return bytes(data)
+
+    @classmethod
+    def from_bytes(cls, data: bytes, offset: int = 0) -> tuple[LedTimerExtended, int]:
+        """Parse timer from response bytes. Returns (timer, bytes_consumed)."""
+        if offset + 7 > len(data):
+            slot = data[offset] if offset < len(data) else 1
+            return cls(slot=slot, active=False), len(data) - offset
+
+        slot = data[offset]
+        flags = data[offset + 1]
+        if flags == 0x00:
+            return cls(slot=slot, active=False), 7
+
+        hour = data[offset + 2]
+        minute = data[offset + 3]
+        if hour > 23 or minute > 59:
+            return cls(slot=slot, active=False), 7
+
+        timer = cls(
+            slot=slot,
+            active=True,
+            hour=hour,
+            minute=minute,
+            repeat_mask=data[offset + 5],
+        )
+
+        action_indicator = data[offset + 6]
+
+        if action_indicator == 0x0E:
+            # Simple or color timer
+            if offset + 11 <= len(data):
+                timer.action_type = data[offset + 10]
+                if timer.action_type == TIMER_ACTION_COLOR and offset + 14 <= len(data):
+                    timer.color_hsv = (
+                        data[offset + 11],
+                        data[offset + 12],
+                        data[offset + 13],
+                    )
+            return timer, min(21, len(data) - offset)
+
+        # Scene timer - look for e1 marker
+        if offset + 9 <= len(data) and data[offset + 7] == 0xE1:
+            effect_type = data[offset + 8]
+            is_gradient = effect_type == TIMER_EFFECT_GRADIENT
+
+            timer.action_type = (
+                TIMER_ACTION_SCENE_GRADIENT
+                if is_gradient
+                else TIMER_ACTION_SCENE_SEGMENTS
+            )
+
+            if is_gradient:
+                if offset + 23 > len(data):
+                    return timer, min(21, len(data) - offset)
+                num_colors_offset, color_start = offset + 22, offset + 23
+                pattern_id = data[offset + 11] if offset + 12 <= len(data) else 0x16
+                for p in ExtendedCustomEffectPattern:
+                    if p.value == pattern_id:
+                        timer.pattern = p
+                        break
+                timer.speed = data[offset + 14] if offset + 15 <= len(data) else 50
+            else:
+                if offset + 14 > len(data):
+                    return timer, min(21, len(data) - offset)
+                num_colors_offset, color_start = offset + 13, offset + 14
+
+            num_colors = data[num_colors_offset]
+            timer.colors = []
+            for i in range(num_colors):
+                c_off = color_start + i * 5
+                if c_off + 3 > len(data):
+                    break
+                timer.colors.append((data[c_off], data[c_off + 1], data[c_off + 2]))
+
+            return timer, min(
+                (color_start - offset) + num_colors * 5, len(data) - offset
+            )
+
+        return timer, min(21, len(data) - offset)
+
+    def __str__(self) -> str:
+        """Return human-readable string representation."""
+        if not self.active:
+            return f"Timer {self.slot}: Unset"
+
+        on_off = "[ON ]" if self.is_on else "[OFF]"
+        time_str = f"{self.hour:02}:{self.minute:02}"
+        repeat_str = ",".join(self.repeat_days) if self.repeat_mask else "Once"
+
+        if self.action_type == TIMER_ACTION_ON:
+            action_str = "Turn On"
+        elif self.action_type == TIMER_ACTION_OFF:
+            action_str = "Turn Off"
+        elif self.action_type == TIMER_ACTION_COLOR and self.color_hsv:
+            h, s, v = self.color_hsv
+            action_str = f"Color (H:{h} S:{s} V:{v})"
+        elif self.action_type == TIMER_ACTION_SCENE_GRADIENT:
+            name = (
+                self.pattern.name.replace("_", " ").title()
+                if self.pattern
+                else "Unknown"
+            )
+            action_str = f"Scene: {name} ({len(self.colors)} colors)"
+        elif self.action_type == TIMER_ACTION_SCENE_SEGMENTS:
+            action_str = f"Colorful ({len(self.colors)} colors)"
+        else:
+            action_str = f"Unknown action: 0x{self.action_type:02x}"
+
+        return f"Timer {self.slot}: {on_off} {time_str}  {repeat_str}  {action_str}"

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -28,18 +28,22 @@ from flux_led.const import (
     WhiteChannelType,
 )
 from flux_led.protocol import (
+    LEDENET_EXTENDED_STATE_RESPONSE_LEN,
     PROTOCOL_LEDENET_8BYTE_AUTO_ON,
     PROTOCOL_LEDENET_8BYTE_DIMMABLE_EFFECTS,
     PROTOCOL_LEDENET_9BYTE,
     PROTOCOL_LEDENET_25BYTE,
     PROTOCOL_LEDENET_ADDRESSABLE_CHRISTMAS,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM,
     PROTOCOL_LEDENET_ORIGINAL,
     LEDENETRawState,
     PowerRestoreState,
     PowerRestoreStates,
+    ProtocolLEDENET8Byte,
     ProtocolLEDENET25Byte,
     ProtocolLEDENETCCT,
     ProtocolLEDENETCCTWrapped,
+    ProtocolLEDENETExtendedCustom,
     RemoteConfig,
 )
 from flux_led.scanner import (
@@ -4342,6 +4346,49 @@ async def test_setup_0xB6_surplife(mock_aio_protocol):
     )
     await task
     assert light.model_num == 0xB6
-    assert light.protocol == PROTOCOL_LEDENET_25BYTE
+    assert light.protocol == PROTOCOL_LEDENET_EXTENDED_CUSTOM
     assert light.color_modes == {COLOR_MODE_RGB, COLOR_MODE_DIM}
     assert "Surplife" in light.model
+    assert light.supports_extended_custom_effects is True
+
+
+def test_protocol_extended_custom_state_response_length():
+    """ProtocolLEDENETExtendedCustom expects the 21-byte extended state."""
+    proto = ProtocolLEDENETExtendedCustom()
+    assert proto.state_response_length == LEDENET_EXTENDED_STATE_RESPONSE_LEN
+
+
+def test_protocol_extended_state_validation_0xB6():
+    """The protocols recognise the extended (0xEA 0x81) state response."""
+    ext = bytes(
+        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
+        + (0x00, 0x00, 0x00, 0x64, 0x64, 0x00, 0x00, 0x00, 0x00, 0x83)
+    )
+    # ProtocolLEDENET8Byte (used while probing) recognises the extended frame.
+    assert ProtocolLEDENET8Byte().is_valid_extended_state_response(ext) is True
+    # The dedicated protocol only accepts the extended format.
+    proto = ProtocolLEDENETExtendedCustom()
+    assert proto.is_valid_state_response(ext) is True
+    assert proto.is_valid_state_response(bytes((0x81,)) + b"\x00" * 13) is False
+
+
+def test_protocol_extended_state_to_state_white_off():
+    """white_brightness of 0 maps to both white channels off."""
+    ext = bytes(
+        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
+        + (0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x83)
+    )
+    result = ProtocolLEDENETExtendedCustom().extended_state_to_state(ext)
+    assert result[9] == 0  # warm_white
+    assert result[11] == 0  # cool_white
+
+
+def test_protocol_named_raw_state_extended_conversion():
+    """named_raw_state converts an extended frame to the standard layout."""
+    ext = bytes(
+        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
+        + (0x00, 0x00, 0x00, 0x64, 0x64, 0x00, 0x00, 0x00, 0x00, 0x83)
+    )
+    result = ProtocolLEDENETExtendedCustom().named_raw_state(ext)
+    assert result.head == 0x81
+    assert result.model_num == 0xB6

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -29,6 +29,9 @@ from flux_led.const import (
     ExtendedCustomEffectOption,
     ExtendedCustomEffectPattern,
     MultiColorEffects,
+    ScribbleBlinkMode,
+    ScribbleEffect,
+    ScribbleLED,
     WhiteChannelType,
 )
 from flux_led.protocol import (
@@ -4415,6 +4418,8 @@ def test_extended_state_led_count():
     # Too-short / invalid frame returns None
     assert proto.extended_state_led_count(b"\xea\x81\x01") is None
     assert proto.extended_state_led_count(b"\x00" * 27) is None
+
+
 def test_extended_custom_effect_pattern_enum_values():
     """Test ExtendedCustomEffectPattern enum has expected values."""
     assert ExtendedCustomEffectPattern.WAVE.value == 0x01
@@ -5145,6 +5150,438 @@ async def test_async_set_custom_segment_colors_0xB6(mock_aio_protocol):
     # Verify it's a wrapped message
     assert written_data[0] == 0xB0
     assert written_data[1] == 0xB1
+
+
+# Scribble (per-LED) feature tests (0xB6)
+
+
+def _inner_of(wrapped: bytearray) -> bytes:
+    """Extract the inner message from a B0B1B2B3-wrapped result.
+
+    wrapper = b0 b1 b2 b3 | 00 01 | ver | counter | len_hi len_lo | inner | cksum
+    """
+    inner_len = (wrapped[8] << 8) | wrapped[9]
+    return bytes(wrapped[10 : 10 + inner_len])
+
+
+ALL_ON_100 = bytes.fromhex("ff" * 12 + "f0")  # N=100, 13 bytes
+ALL_ON_80 = bytes.fromhex("ff" * 10)  # N=80, 10 bytes
+OFF0_80 = bytes.fromhex("80" + "00" * 9)  # N=80, only LED 0
+GROUP_40_79_80 = bytes.fromhex("00" * 5 + "ff" * 5)  # N=80, LEDs 40-79
+
+
+def _h(s: str) -> bytes:
+    return bytes.fromhex(s.replace(" ", ""))
+
+
+def test_scribble_bitmap_n100():
+    proto = ProtocolLEDENETExtendedCustom()
+    bitmap = proto._scribble_bitmap(range(100), 100)
+    assert len(bitmap) == 13
+    assert bitmap == ALL_ON_100
+    assert bitmap[-1] == 0xF0
+
+
+def test_scribble_bitmap_n80():
+    proto = ProtocolLEDENETExtendedCustom()
+    bitmap = proto._scribble_bitmap(range(80), 80)
+    assert len(bitmap) == 10
+    assert bitmap == ALL_ON_80
+
+
+def test_scribble_bitmap_led0():
+    proto = ProtocolLEDENETExtendedCustom()
+    bitmap = proto._scribble_bitmap([0], 80)
+    assert bitmap[0] == 0x80
+
+
+def test_scribble_bitmap_led7():
+    proto = ProtocolLEDENETExtendedCustom()
+    bitmap = proto._scribble_bitmap([7], 80)
+    assert bitmap[0] == 0x01
+
+
+def test_scribble_bitmap_out_of_range():
+    proto = ProtocolLEDENETExtendedCustom()
+    with pytest.raises(ValueError):
+        proto._scribble_bitmap([80], 80)
+    with pytest.raises(ValueError):
+        proto._scribble_bitmap([-1], 80)
+
+
+def test_scribble_paint_all_green_static_n100():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(
+        proto.construct_scribble_paint(
+            effect=0x00,
+            direction=0x01,
+            density=0x50,
+            speed=0x64,
+            blink_mode=0x00,
+            h2=0x3C,
+            s=0x64,
+            v=0x64,
+            white=0x00,
+            blink_speed=0x64,
+            num_leds=100,
+        )
+    )
+    assert inner[:2] == b"\xe1\x26"
+    assert inner == _h("e1 26 00 01 50 64 00 3c 64 64 00 00 64") + ALL_ON_100
+
+
+def test_scribble_paint_blue_50pct():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(
+        proto.construct_scribble_paint(h2=0x78, s=0x64, v=0x32, num_leds=80)
+    )
+    assert inner == _h("e1 26 00 01 50 64 00 78 64 32 00 00 64") + ALL_ON_80
+
+
+def test_scribble_paint_white_100():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(
+        proto.construct_scribble_paint(h2=0x78, s=0x64, v=0x00, white=0x64, num_leds=80)
+    )
+    assert inner == _h("e1 26 00 01 50 64 00 78 64 00 00 64 64") + ALL_ON_80
+
+
+def test_scribble_paint_fast_blink_50():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(
+        proto.construct_scribble_paint(
+            blink_mode=0x10, h2=0x78, s=0x64, v=0x64, blink_speed=0x32, num_leds=80
+        )
+    )
+    assert inner == _h("e1 26 00 01 50 64 10 78 64 64 00 00 32") + ALL_ON_80
+
+
+def test_scribble_paint_slow_blink_50():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(
+        proto.construct_scribble_paint(
+            blink_mode=0x08, h2=0x78, s=0x64, v=0x64, blink_speed=0x32, num_leds=80
+        )
+    )
+    assert inner == _h("e1 26 00 01 50 64 08 78 64 64 00 00 32") + ALL_ON_80
+
+
+def test_scribble_paint_flowing_r2l_speed50():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(
+        proto.construct_scribble_paint(
+            effect=0x01,
+            direction=0x02,
+            speed=0x32,
+            h2=0x78,
+            s=0x64,
+            v=0x64,
+            num_leds=80,
+        )
+    )
+    assert inner == _h("e1 26 01 02 50 32 00 78 64 64 00 00 64") + ALL_ON_80
+
+
+def test_scribble_paint_twinkling_d50_s61():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(
+        proto.construct_scribble_paint(
+            effect=0x03,
+            direction=0x02,
+            density=0x32,
+            speed=0x3D,
+            h2=0x78,
+            s=0x64,
+            v=0x64,
+            num_leds=80,
+        )
+    )
+    assert inner == _h("e1 26 03 02 32 3d 00 78 64 64 00 00 64") + ALL_ON_80
+
+
+def test_scribble_paint_off_bulb0_n80():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(
+        proto.construct_scribble_paint(
+            effect=0x00,
+            density=0x50,
+            h2=0x00,
+            s=0x00,
+            v=0x00,
+            blink_speed=0x64,
+            bitmap_leds=[0],
+            num_leds=80,
+        )
+    )
+    assert inner == _h("e1 26 00 01 50 64 00 00 00 00 00 00 64") + OFF0_80
+
+
+def test_scribble_paint_flowing_blue_group_n80():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(
+        proto.construct_scribble_paint(
+            effect=0x01,
+            direction=0x02,
+            density=0x50,
+            speed=0x26,
+            h2=0x78,
+            s=0x64,
+            v=0x64,
+            blink_speed=0x64,
+            bitmap_leds=list(range(40, 80)),
+            num_leds=80,
+        )
+    )
+    assert inner == _h("e1 26 01 02 50 26 00 78 64 64 00 00 64") + GROUP_40_79_80
+
+
+def test_scribble_init_n80():
+    proto = ProtocolLEDENETExtendedCustom()
+    inner = _inner_of(proto.construct_scribble_init(80))
+    assert inner[:9] == _h("e1 23 01 00 01 50 64 00 50")
+    assert inner[9:] == _h("00 00 00 00 00 00 64") * 80
+    assert len(inner) == 569  # 9 + 7*80
+
+
+@pytest.mark.asyncio
+async def test_generate_scribble_init_invalid(mock_aio_protocol):
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    with pytest.raises(ValueError, match=r"num_leds must be 1\.\.255"):
+        light._generate_scribble_init(0)
+    # 256 exceeds the one-byte E1 23 count / bitmap addressing limit and must
+    # raise the descriptive error, not the generic "byte must be in range".
+    with pytest.raises(ValueError, match=r"num_leds must be 1\.\.255, got 256"):
+        light._generate_scribble_init(256)
+
+
+@pytest.mark.asyncio
+async def test_scribble_paint_groups_num_leds_over_255_raises(mock_aio_protocol):
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    light._extended_led_count = None  # bypass the led_count mismatch check
+    leds = [ScribbleLED(rgb=(255, 0, 0))] * 256
+    with pytest.raises(ValueError, match=r"num_leds must be 1\.\.255, got 256"):
+        light._scribble_paint_groups(leds, 0x00, 0x01, 0x50, 0x64, 256)
+
+
+@pytest.mark.asyncio
+async def test_scribble_paint_groups_rgb_and_white_raises(mock_aio_protocol):
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    leds = [ScribbleLED(rgb=(255, 0, 0), white=50)] + [ScribbleLED()] * 79
+    with pytest.raises(ValueError):
+        light._scribble_paint_groups(leds, 0x00, 0x01, 0x50, 0x64, 80)
+
+
+@pytest.mark.asyncio
+async def test_scribble_paint_groups_channel_out_of_range_raises(mock_aio_protocol):
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    leds = [ScribbleLED(rgb=(300, 0, 0))] + [ScribbleLED()] * 79
+    with pytest.raises(ValueError):
+        light._scribble_paint_groups(leds, 0x00, 0x01, 0x50, 0x64, 80)
+
+
+@pytest.mark.asyncio
+async def test_scribble_paint_groups_effect_int_and_enum(mock_aio_protocol):
+    """effect accepts a raw int id (e.g. 4, unnamed) or a ScribbleEffect; the
+    device-valid range is 0x00-0x08, anything else raises ValueError."""
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    leds = [ScribbleLED(rgb=(255, 0, 0))] * 80
+    # raw int id not exposed as a name (3,4,6,7 are valid on-device)
+    assert (
+        _inner_of(light._scribble_paint_groups(leds, 4, 0x01, 0x50, 0x64, 80)[0])[2]
+        == 4
+    )
+    # enum still works
+    assert (
+        _inner_of(
+            light._scribble_paint_groups(
+                leds, ScribbleEffect.FLOWING, 0x01, 0x50, 0x64, 80
+            )[0]
+        )[2]
+        == 0x01
+    )
+    # out-of-range id (device accepts only 0x00-0x08)
+    with pytest.raises(ValueError):
+        light._scribble_paint_groups(leds, 9, 0x01, 0x50, 0x64, 80)
+
+
+@pytest.mark.asyncio
+async def test_scribble_paint_groups_wrong_count_raises(mock_aio_protocol):
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    assert light.led_count == 80
+    leds = [ScribbleLED(rgb=(255, 0, 0))] * 40
+    with pytest.raises(ValueError):
+        light._scribble_paint_groups(leds, 0x00, 0x01, 0x50, 0x64, 40)
+
+
+@pytest.mark.asyncio
+async def test_scribble_paint_groups_empty_raises(mock_aio_protocol):
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    with pytest.raises(ValueError):
+        light._scribble_paint_groups([], 0x00, 0x01, 0x50, 0x64, 0)
+
+
+@pytest.mark.asyncio
+async def test_scribble_paint_groups_two_color_static(mock_aio_protocol):
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    leds = [ScribbleLED(rgb=(255, 0, 0))] * 40 + [ScribbleLED(rgb=(0, 0, 255))] * 40
+    msgs = light._scribble_paint_groups(leds, 0x00, 0x01, 0x50, 0x64, 80)
+    assert len(msgs) == 2  # red group then blue group, first-appearance order
+    red = _inner_of(msgs[0])
+    blue = _inner_of(msgs[1])
+    # red occupies LEDs 0-39, blue 40-79
+    assert red[13:] == _h("ff" * 5 + "00" * 5)
+    assert blue[13:] == GROUP_40_79_80
+    # blue hue byte (h2) = 0x78
+    assert blue[7] == 0x78
+
+
+@pytest.mark.asyncio
+async def test_scribble_paint_groups_blink_grouping(mock_aio_protocol):
+    """LEDs with different blink modes split into separate E1 26 groups."""
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    leds = [ScribbleLED(rgb=(255, 0, 0), blink_mode=ScribbleBlinkMode.FAST)] * 40 + [
+        ScribbleLED(rgb=(255, 0, 0), blink_mode=ScribbleBlinkMode.NONE)
+    ] * 40
+    msgs = light._scribble_paint_groups(leds, 0x00, 0x01, 0x50, 0x64, 80)
+    assert len(msgs) == 2  # same color, different blink -> two groups
+    fast = _inner_of(msgs[0])
+    steady = _inner_of(msgs[1])
+    assert fast[6] == 0x10  # FAST blink byte
+    assert steady[6] == 0x00  # NONE blink byte
+
+
+@pytest.mark.asyncio
+async def test_scribble_paint_groups_off_group_color_zero(mock_aio_protocol):
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    leds = [ScribbleLED(rgb=(255, 0, 0))] + [ScribbleLED()] * 79
+    msgs = light._scribble_paint_groups(leds, 0x00, 0x01, 0x50, 0x64, 80)
+    assert len(msgs) == 2
+    off = _inner_of(msgs[1])
+    # off group: all-zero color, header matches the off golden
+    assert off[:13] == _h("e1 26 00 01 50 64 00 00 00 00 00 00 64")
+    assert off[13:] == _h("7f" + "ff" * 8 + "ff")  # LEDs 1-79 set
+
+
+async def _setup_scribble_light(mock_aio_protocol, led_count_byte=0x50):
+    """Set up a 0xB6 AIO light with a known led_count from state byte 18."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, _protocol = await mock_aio_protocol()
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                led_count_byte,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+    transport.reset_mock()
+    return light, transport
+
+
+@pytest.mark.asyncio
+async def test_async_set_scribble_static_two_color(mock_aio_protocol):
+    """STATIC 2-color config sends E1 23 init + one E1 26 per color group."""
+    light, _transport = await _setup_scribble_light(mock_aio_protocol)
+    assert light.led_count == 80
+
+    sent = []
+    with patch.object(light, "_async_send_msg", side_effect=lambda m: sent.append(m)):
+        leds = [ScribbleLED(rgb=(255, 0, 0))] * 40 + [ScribbleLED(rgb=(0, 0, 255))] * 40
+        await light.async_set_scribble(leds, effect=ScribbleEffect.STATIC)
+
+    assert len(sent) == 3
+    init = _inner_of(sent[0])
+    assert init[:2] == b"\xe1\x23"
+    assert len(init) == 569
+    red = _inner_of(sent[1])
+    blue = _inner_of(sent[2])
+    assert red[:2] == b"\xe1\x26"
+    assert red[13:] == _h("ff" * 5 + "00" * 5)
+    assert blue[13:] == GROUP_40_79_80
+    assert blue[7] == 0x78  # blue hue
+
+
+@pytest.mark.asyncio
+async def test_async_set_scribble_no_enter_mode(mock_aio_protocol):
+    """enter_mode=False sends no E1 23, one E1 26 per group."""
+    light, _transport = await _setup_scribble_light(mock_aio_protocol)
+    sent = []
+    with patch.object(light, "_async_send_msg", side_effect=lambda m: sent.append(m)):
+        leds = [ScribbleLED(rgb=(255, 0, 0))] * 40 + [ScribbleLED(rgb=(0, 0, 255))] * 40
+        await light.async_set_scribble(leds, enter_mode=False)
+    assert len(sent) == 2
+    assert _inner_of(sent[0])[:2] == b"\xe1\x26"
+    assert _inner_of(sent[1])[:2] == b"\xe1\x26"
+
+
+@pytest.mark.asyncio
+async def test_async_set_scribble_flowing_blue_group(mock_aio_protocol):
+    """FLOWING effect: blue group paint matches the captured golden."""
+    light, _transport = await _setup_scribble_light(mock_aio_protocol)
+    sent = []
+    with patch.object(light, "_async_send_msg", side_effect=lambda m: sent.append(m)):
+        leds = [ScribbleLED(rgb=(255, 0, 0))] * 40 + [ScribbleLED(rgb=(0, 0, 255))] * 40
+        await light.async_set_scribble(
+            leds,
+            effect=ScribbleEffect.FLOWING,
+            direction=ExtendedCustomEffectDirection.RIGHT_TO_LEFT,
+            density=0x50,
+            speed=0x26,
+        )
+    assert len(sent) == 3
+    red = _inner_of(sent[1])
+    blue = _inner_of(sent[2])
+    # blue group matches the captured golden
+    assert blue == _h("e1 26 01 02 50 26 00 78 64 64 00 00 64") + GROUP_40_79_80
+    # red group carries red color on LEDs 0-39 under the same effect
+    assert red[:7] == _h("e1 26 01 02 50 26 00")
+    assert red[13:] == _h("ff" * 5 + "00" * 5)
+
+
+@pytest.mark.asyncio
+async def test_async_set_scribble_off_group(mock_aio_protocol):
+    """Mixed lit + off config: off group paints all-zero color."""
+    light, _transport = await _setup_scribble_light(mock_aio_protocol)
+    sent = []
+    with patch.object(light, "_async_send_msg", side_effect=lambda m: sent.append(m)):
+        leds = [ScribbleLED(rgb=(255, 0, 0))] + [ScribbleLED()] * 79
+        await light.async_set_scribble(leds, enter_mode=False)
+    assert len(sent) == 2
+    red = _inner_of(sent[0])
+    off = _inner_of(sent[1])
+    assert red[13:] == OFF0_80
+    assert off[:13] == _h("e1 26 00 01 50 64 00 00 00 00 00 00 64")
+
+
+@pytest.mark.asyncio
+async def test_supports_scribble_property(mock_aio_protocol):
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    assert light.supports_scribble is True
 
 
 # Tests for extended_custom_effect_pattern_list property (base_device.py line 658)

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import logging
 import time
+from optparse import OptionParser
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -39,6 +40,7 @@ from flux_led.const import (
     ScribbleLED,
     WhiteChannelType,
 )
+from flux_led.fluxled import processSetTimerArgs, processSetTimerArgsExtended
 from flux_led.protocol import (
     LEDENET_EXTENDED_STATE_RESPONSE_LEN,
     PROTOCOL_LEDENET_8BYTE_AUTO_ON,
@@ -6178,3 +6180,231 @@ def test_led_timer_extended_from_bytes_truncated():
     data = bytes([0x01, 0xF0, 12, 30, 0])
     _timer, consumed = LedTimerExtended.from_bytes(data, 0)
     assert consumed == 5  # Returns what's available
+
+
+
+def test_cli_process_set_timer_args_extended_inactive():
+    """Test CLI parsing for inactive extended timer."""
+    parser = OptionParser()
+    timer = processSetTimerArgsExtended(parser, ["1", "inactive", ""])
+    assert timer.slot == 1
+    assert timer.active is False
+    assert timer.action_type == TIMER_ACTION_OFF
+
+
+def test_cli_process_set_timer_args_extended_poweroff():
+    """Test CLI parsing for poweroff extended timer."""
+    parser = OptionParser()
+    timer = processSetTimerArgsExtended(
+        parser, ["2", "poweroff", "time:1430;repeat:12345"]
+    )
+    assert timer.slot == 2
+    assert timer.active is True
+    assert timer.hour == 14
+    assert timer.minute == 30
+    assert timer.action_type == TIMER_ACTION_OFF
+    # repeat 12345 = Mon|Tue|Wed|Thu|Fri = bits 1,2,3,4,5 = 0x3E
+    assert timer.repeat_mask == 0x3E
+
+
+def test_cli_process_set_timer_args_extended_default_on():
+    """Test CLI parsing for default (on) extended timer."""
+    parser = OptionParser()
+    timer = processSetTimerArgsExtended(parser, ["3", "default", "time:0830;repeat:06"])
+    assert timer.slot == 3
+    assert timer.active is True
+    assert timer.hour == 8
+    assert timer.minute == 30
+    assert timer.action_type == TIMER_ACTION_ON
+    # repeat 06 = Sun|Sat = bits 7,6 = 0x80|0x40 = 0xC0
+    assert timer.repeat_mask == 0xC0
+
+
+def test_cli_process_set_timer_args_extended_color():
+    """Test CLI parsing for color extended timer."""
+    parser = OptionParser()
+    # Use color name instead of hex code (hex needs # prefix)
+    timer = processSetTimerArgsExtended(
+        parser, ["4", "color", "time:2100;repeat:0123456;color:red"]
+    )
+    assert timer.slot == 4
+    assert timer.active is True
+    assert timer.hour == 21
+    assert timer.minute == 0
+    assert timer.action_type == TIMER_ACTION_COLOR
+    assert timer.color_hsv is not None
+    # red should have hue=0
+    assert timer.color_hsv[0] == 0  # hue
+
+
+def test_cli_process_set_timer_args_extended_color_with_brightness():
+    """Test CLI parsing for color extended timer with brightness."""
+    parser = OptionParser()
+    # Use hex with # prefix
+    timer = processSetTimerArgsExtended(
+        parser, ["5", "color", "time:1200;repeat:1;color:#00ff00;brightness:50"]
+    )
+    assert timer.slot == 5
+    assert timer.active is True
+    assert timer.action_type == TIMER_ACTION_COLOR
+    assert timer.color_hsv is not None
+    # Check brightness is 50
+    assert timer.color_hsv[2] == 50
+
+
+def test_cli_process_set_timer_args_extended_weekend_repeat():
+    """Test CLI parsing for weekend repeat (0=Sun, 6=Sat)."""
+    parser = OptionParser()
+    timer = processSetTimerArgsExtended(
+        parser, ["1", "poweroff", "time:2200;repeat:06"]
+    )
+    # repeat 06 = Sun|Sat = bit7 | bit6 = 0x80 | 0x40 = 0xC0
+    assert timer.repeat_mask == 0xC0
+
+
+def test_cli_process_set_timer_args_extended_everyday_repeat():
+    """Test CLI parsing for everyday repeat (0123456)."""
+    parser = OptionParser()
+    timer = processSetTimerArgsExtended(
+        parser, ["1", "default", "time:0700;repeat:0123456"]
+    )
+    # repeat 0123456 = Sun|Mon|Tue|Wed|Thu|Fri|Sat
+    # bit7=Sun + bits1-6 = 0x80 | 0x7E = 0xFE
+    assert timer.repeat_mask == 0xFE
+
+
+def test_cli_process_set_timer_args_standard_inactive():
+    """Test CLI parsing for inactive standard timer."""
+    parser = OptionParser()
+    timer = processSetTimerArgs(parser, ["1", "inactive", ""])
+    assert timer.isActive() is False
+
+
+def test_cli_process_set_timer_args_standard_poweroff():
+    """Test CLI parsing for poweroff standard timer."""
+    parser = OptionParser()
+    timer = processSetTimerArgs(parser, ["2", "poweroff", "time:1430;repeat:12345"])
+    assert timer.isActive() is True
+    assert timer.hour == 14
+    assert timer.minute == 30
+    # Check it's a turn-off timer
+    assert timer.turn_on is False
+
+
+def test_cli_process_set_timer_args_standard_default():
+    """Test CLI parsing for default (on) standard timer."""
+    parser = OptionParser()
+    timer = processSetTimerArgs(parser, ["3", "default", "time:0830;repeat:06"])
+    assert timer.isActive() is True
+    assert timer.hour == 8
+    assert timer.minute == 30
+
+
+def test_cli_process_set_timer_args_standard_color():
+    """Test CLI parsing for color standard timer."""
+    parser = OptionParser()
+    timer = processSetTimerArgs(
+        parser, ["4", "color", "time:2100;repeat:0123456;color:255,0,0"]
+    )
+    assert timer.isActive() is True
+    assert timer.hour == 21
+    assert timer.minute == 0
+    assert timer.red == 255
+    assert timer.green == 0
+    assert timer.blue == 0
+
+
+def test_cli_process_set_timer_args_standard_warmwhite():
+    """Test CLI parsing for warmwhite standard timer."""
+    parser = OptionParser()
+    timer = processSetTimerArgs(
+        parser, ["5", "warmwhite", "time:2200;repeat:12345;level:75"]
+    )
+    assert timer.isActive() is True
+    assert timer.hour == 22
+    assert timer.minute == 0
+    # 75% is converted to byte: int((75 * 255) / 100) = 191
+    assert timer.warmth_level == 191
+
+
+def test_cli_process_set_timer_args_standard_preset():
+    """Test CLI parsing for preset standard timer."""
+    parser = OptionParser()
+    timer = processSetTimerArgs(
+        parser, ["6", "preset", "time:1800;repeat:06;code:37;speed:50"]
+    )
+    assert timer.isActive() is True
+    assert timer.hour == 18
+    assert timer.minute == 0
+    assert timer.pattern_code == 37
+
+
+# =============================================================================
+# Timer Display Formatting Tests (__str__)
+# =============================================================================
+
+
+def test_led_timer_standard_str_inactive():
+    """Test LedTimer.__str__ for inactive timer."""
+    timer = LedTimer()
+    timer.setActive(False)
+    assert str(timer) == "Unset"
+
+
+def test_led_timer_standard_str_on():
+    """Test LedTimer.__str__ for turn-on timer."""
+    timer = LedTimer()
+    timer.setActive(True)
+    timer.setTime(8, 30)
+    timer.setModeDefault()
+    timer.setRepeatMask(LedTimer.Weekdays)
+
+    s = str(timer)
+    assert "[ON ]" in s
+    assert "08:30" in s
+    assert "Mo" in s
+    assert "Tu" in s
+    assert "Fr" in s
+
+
+def test_led_timer_standard_str_off():
+    """Test LedTimer.__str__ for turn-off timer."""
+    timer = LedTimer()
+    timer.setActive(True)
+    timer.setTime(22, 0)
+    timer.setModeTurnOff()
+    timer.setRepeatMask(LedTimer.Everyday)
+
+    s = str(timer)
+    assert "[OFF]" in s
+    assert "22:00" in s
+
+
+def test_led_timer_standard_str_once():
+    """Test LedTimer.__str__ for one-time timer."""
+    timer = LedTimer()
+    timer.setActive(True)
+    timer.setTime(14, 30)
+    timer.setModeDefault()
+    timer.setDate(2025, 12, 25)
+
+    s = str(timer)
+    assert "[ON ]" in s
+    assert "14:30" in s
+    assert "Once" in s
+    assert "2025-12-25" in s
+
+
+def test_led_timer_standard_str_color():
+    """Test LedTimer.__str__ for color timer."""
+    timer = LedTimer()
+    timer.setActive(True)
+    timer.setTime(19, 0)
+    timer.setModeColor(255, 0, 0)
+    timer.setRepeatMask(LedTimer.Weekend)
+
+    s = str(timer)
+    assert "[ON ]" in s
+    assert "19:00" in s
+    assert "Sa" in s
+    assert "Su" in s

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -25,6 +25,11 @@ from flux_led.const import (
     MAX_TEMP,
     MIN_TEMP,
     PUSH_UPDATE_INTERVAL,
+    TIMER_ACTION_COLOR,
+    TIMER_ACTION_OFF,
+    TIMER_ACTION_ON,
+    TIMER_ACTION_SCENE_GRADIENT,
+    TIMER_ACTION_SCENE_SEGMENTS,
     ExtendedCustomEffectDirection,
     ExtendedCustomEffectOption,
     ExtendedCustomEffectPattern,
@@ -59,7 +64,7 @@ from flux_led.scanner import (
     is_legacy_device,
     merge_discoveries,
 )
-from flux_led.timer import LedTimer
+from flux_led.timer import LedTimer, LedTimerExtended
 
 IP_ADDRESS = "127.0.0.1"
 MODEL_NUM_HEX = "0x35"
@@ -5750,3 +5755,426 @@ async def test_named_effect_extended_custom_meteor(mock_aio_protocol):
     await task
 
     assert light.effect == "Meteor"
+
+
+def test_protocol_construct_get_timers_0xB6():
+    """Test timer query construction for 0xB6 device."""
+    proto = ProtocolLEDENETExtendedCustom()
+    msg = proto.construct_get_timers()
+
+    # Should be wrapped message with inner content [0xE0, 0x06]
+    assert msg[0:6] == bytes([0xB0, 0xB1, 0xB2, 0xB3, 0x00, 0x01])
+    # Version byte at position 6
+    assert msg[6] == 0x01
+    # Inner message length at positions 8-9 (should be 2)
+    assert msg[8] == 0x00
+    assert msg[9] == 0x02
+    # Inner message starts at position 10
+    assert msg[10] == 0xE0
+    assert msg[11] == 0x06
+
+
+def test_protocol_is_valid_timers_response_0xB6():
+    """Test timer response validation for 0xB6 device."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Valid response starts with e0 06
+    assert proto.is_valid_timers_response(bytes([0xE0, 0x06])) is True
+    assert proto.is_valid_timers_response(bytes([0xE0, 0x06, 0x01, 0x02])) is True
+
+    # Invalid responses
+    assert proto.is_valid_timers_response(bytes([0xE0])) is False
+    assert proto.is_valid_timers_response(bytes([0x01, 0x22])) is False
+    assert proto.is_valid_timers_response(bytes([])) is False
+
+
+def test_protocol_parse_get_timers_empty_0xB6():
+    """Test parsing empty timer response for 0xB6 device."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Empty response (no timers configured)
+    response = bytes([0xE0, 0x06])
+    timers = proto.parse_get_timers(response)
+
+    assert len(timers) == 0
+
+
+def test_protocol_parse_get_timers_single_0xB6():
+    """Test parsing single timer response for 0xB6 device."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Response with one timer: 13:25 OFF, no repeat
+    # Format: e0 06 [slot1: 21 bytes] [empty slots 2-6: 7 bytes each]
+    response = bytes.fromhex(
+        "e006"  # Header
+        "01f00d1900000ee001002400000000000000000000"  # Slot 1: 13:25 OFF
+        "0264640000690003000000000000040000000000000500000000000006000000000000"  # Slots 2-6 empty
+    )
+    timers = proto.parse_get_timers(response)
+
+    assert len(timers) == 6
+
+    # First timer should be active
+    timer1 = timers[0]
+    assert timer1.slot == 1
+    assert timer1.active is True
+    assert timer1.hour == 13
+    assert timer1.minute == 25
+    assert timer1.repeat_mask == 0
+    assert timer1.action_type == 0x24  # OFF
+
+    # Remaining timers should be inactive
+    for i in range(1, 6):
+        assert timers[i].active is False
+
+
+def test_protocol_parse_get_timers_multiple_0xB6():
+    """Test parsing multiple timer response for 0xB6 device."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Response with three timers (from actual packet capture)
+    # Format: e0 06 [slot1: 21 bytes] [slot2: 21 bytes] [slot3: 21 bytes] [slots 4-6: 7 bytes each]
+    response = bytes.fromhex(
+        "e006"  # Header
+        "01f00d1900000ee001002400000000000000000000"  # Slot 1: 13:25 OFF
+        "02f00f2300000ee001002400000000000000000000"  # Slot 2: 15:35 OFF
+        "03f00d2100000ee001002400000000000000000000"  # Slot 3: 13:33 OFF
+        "04000000000000"  # Slot 4 empty
+        "05000000000000"  # Slot 5 empty
+        "06000000000000"  # Slot 6 empty
+    )
+    timers = proto.parse_get_timers(response)
+
+    assert len(timers) == 6
+
+    # Check active timers
+    assert timers[0].slot == 1
+    assert timers[0].hour == 13
+    assert timers[0].minute == 25
+    assert timers[0].active is True
+
+    assert timers[1].slot == 2
+    assert timers[1].hour == 15
+    assert timers[1].minute == 35
+    assert timers[1].active is True
+
+    assert timers[2].slot == 3
+    assert timers[2].hour == 13
+    assert timers[2].minute == 33
+    assert timers[2].active is True
+
+    # Check inactive timers
+    assert timers[3].active is False
+    assert timers[4].active is False
+    assert timers[5].active is False
+
+
+def test_protocol_parse_get_timers_with_color_0xB6():
+    """Test parsing timer with color action for 0xB6 device."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Build a timer response with color action (0xa1)
+    # Slot 1: 17:15, Sun+Tue repeat (0x84), color action with HSV
+    inner_slot1 = bytes.fromhex("01f0110f00840ee00100a17be432000000000000")
+    inner_empty = bytes.fromhex(
+        "02000000000000030000000000000400000000000005000000000000060000000000"
+    )
+
+    response = bytes([0xE0, 0x06]) + inner_slot1 + inner_empty
+    timers = proto.parse_get_timers(response)
+
+    # Check first timer
+    timer1 = timers[0]
+    assert timer1.slot == 1
+    assert timer1.hour == 17
+    assert timer1.minute == 15
+    assert timer1.repeat_mask == 0x84  # Sun + Tue
+    assert timer1.action_type == 0xA1  # Color
+    assert timer1.color_hsv == (0x7B, 0xE4, 0x32)  # (123, 228, 50)
+
+
+def test_led_timer_extended_simple_on():
+    """Test LedTimerExtended for simple ON action."""
+    timer = LedTimerExtended(
+        slot=1,
+        active=True,
+        hour=8,
+        minute=30,
+        repeat_mask=LedTimerExtended.Weekdays,
+        action_type=TIMER_ACTION_ON,
+    )
+
+    assert timer.is_on is True
+    assert timer.is_scene is False
+    assert timer.is_color is False
+    assert timer.repeat_days == ["Mon", "Tue", "Wed", "Thu", "Fri"]
+
+    # Test serialization
+    data = timer.to_bytes()
+    assert data[0] == 0xF0  # Active flag
+    assert data[1] == 8  # Hour
+    assert data[2] == 30  # Minute
+    assert data[9] == 0x23  # ON action
+
+
+def test_led_timer_extended_simple_off():
+    """Test LedTimerExtended for simple OFF action."""
+    timer = LedTimerExtended(
+        slot=2,
+        active=True,
+        hour=22,
+        minute=0,
+        repeat_mask=0,  # No repeat
+        action_type=TIMER_ACTION_OFF,
+    )
+
+    assert timer.is_on is False
+    assert timer.repeat_days == []
+
+    data = timer.to_bytes()
+    assert data[9] == 0x24  # OFF action
+
+
+def test_led_timer_extended_color():
+    """Test LedTimerExtended for color action."""
+    timer = LedTimerExtended(
+        slot=1,
+        active=True,
+        hour=17,
+        minute=15,
+        repeat_mask=0x84,  # Sun + Tue
+        action_type=TIMER_ACTION_COLOR,
+        color_hsv=(123, 228, 50),
+    )
+
+    assert timer.is_on is True
+    assert timer.is_color is True
+    assert timer.repeat_days == ["Tue", "Sun"]
+
+    data = timer.to_bytes()
+    assert data[9] == 0xA1  # Color action
+    assert data[10] == 123  # Hue
+    assert data[11] == 228  # Saturation
+    assert data[12] == 50  # Brightness
+
+
+def test_led_timer_extended_inactive():
+    """Test LedTimerExtended for inactive timer."""
+    timer = LedTimerExtended(
+        slot=3,
+        active=False,
+    )
+
+    data = timer.to_bytes()
+    # Inactive timer should be all zeros
+    assert data == bytes(20)
+
+
+def test_led_timer_extended_from_bytes_simple():
+    """Test LedTimerExtended.from_bytes for simple timer."""
+    # Simple OFF timer: slot 1, 13:25, no repeat (21 bytes)
+    data = bytes.fromhex("01f00d1900000ee001002400000000000000000000")
+
+    timer, consumed = LedTimerExtended.from_bytes(data, 0)
+
+    assert consumed == 21
+    assert timer.slot == 1
+    assert timer.active is True
+    assert timer.hour == 13
+    assert timer.minute == 25
+    assert timer.repeat_mask == 0
+    assert timer.action_type == 0x24  # OFF
+
+
+def test_led_timer_extended_from_bytes_empty():
+    """Test LedTimerExtended.from_bytes for empty slot."""
+    # Empty slot
+    data = bytes.fromhex("0300000000000000")
+
+    timer, consumed = LedTimerExtended.from_bytes(data, 0)
+
+    assert consumed == 7
+    assert timer.slot == 3
+    assert timer.active is False
+
+
+def test_led_timer_extended_str():
+    """Test LedTimerExtended string representation."""
+    timer_off = LedTimerExtended(
+        slot=1, active=True, hour=22, minute=0, action_type=TIMER_ACTION_OFF
+    )
+    assert "OFF" in str(timer_off)
+    assert "22:00" in str(timer_off)
+
+    timer_on = LedTimerExtended(
+        slot=2,
+        active=True,
+        hour=8,
+        minute=30,
+        repeat_mask=LedTimerExtended.Weekdays,
+        action_type=TIMER_ACTION_ON,
+    )
+    assert "ON" in str(timer_on)
+    assert "Mon" in str(timer_on)
+
+    timer_inactive = LedTimerExtended(slot=3, active=False)
+    assert "Unset" in str(timer_inactive)
+
+
+def test_protocol_construct_set_timer_0xB6():
+    """Test timer set construction for 0xB6 device."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    timer = LedTimerExtended(
+        slot=1,
+        active=True,
+        hour=13,
+        minute=25,
+        repeat_mask=0,
+        action_type=TIMER_ACTION_OFF,
+    )
+
+    msg = proto.construct_set_timer(timer)
+
+    # Should be wrapped message
+    assert msg[0:6] == bytes([0xB0, 0xB1, 0xB2, 0xB3, 0x00, 0x01])
+    # Version byte
+    assert msg[6] == 0x01
+    # Inner message starts at position 10
+    assert msg[10] == 0xE0  # Extended command
+    assert msg[11] == 0x05  # Set timer command
+    assert msg[12] == 0x01  # Slot number
+
+
+def test_led_timer_extended_scene_gradient():
+    """Test LedTimerExtended for scene gradient action."""
+    timer = LedTimerExtended(
+        slot=1,
+        active=True,
+        hour=18,
+        minute=30,
+        repeat_mask=LedTimerExtended.Everyday,
+        action_type=TIMER_ACTION_SCENE_GRADIENT,
+        pattern=ExtendedCustomEffectPattern.WAVE,
+        speed=80,
+        colors=[(100, 100, 100), (50, 50, 50)],
+    )
+
+    assert timer.is_on is True
+    assert timer.is_scene is True
+    assert timer.is_color is False
+
+    # Test serialization
+    data = timer.to_bytes()
+    assert data[0] == 0xF0  # Active flag
+    assert data[1] == 18  # Hour
+    assert data[2] == 30  # Minute
+    assert data[5] == TIMER_ACTION_SCENE_GRADIENT
+    assert data[6] == 0xE1  # Effect marker
+    assert data[7] == 0x21  # Gradient effect type
+
+    # Test __str__
+    s = str(timer)
+    assert "Scene: Wave" in s
+    assert "2 colors" in s
+
+
+def test_led_timer_extended_scene_segments():
+    """Test LedTimerExtended for scene segments (colorful) action."""
+    timer = LedTimerExtended(
+        slot=2,
+        active=True,
+        hour=20,
+        minute=0,
+        repeat_mask=LedTimerExtended.Weekend,
+        action_type=TIMER_ACTION_SCENE_SEGMENTS,
+        colors=[(180, 100, 100), (0, 100, 100), (60, 100, 100)],
+    )
+
+    assert timer.is_scene is True
+
+    # Test serialization
+    data = timer.to_bytes()
+    assert data[5] == TIMER_ACTION_SCENE_SEGMENTS
+    assert data[6] == 0xE1  # Effect marker
+    assert data[7] == 0x22  # Segments effect type
+
+    # Test __str__
+    s = str(timer)
+    assert "Colorful" in s
+    assert "3 colors" in s
+
+
+def test_led_timer_extended_from_bytes_scene_gradient():
+    """Test LedTimerExtended.from_bytes for scene gradient timer."""
+    # Scene gradient timer from real device data:
+    # slot=4, 18:38, repeat=0x0f, action=0x29, e1 21 header, 5 colors
+    data = bytes.fromhex(
+        "04f0122600f629e12100500300016450000000000000050c646400001e646400005a646400006ce464000096646400"
+    )
+
+    timer, _consumed = LedTimerExtended.from_bytes(data, 0)
+
+    assert timer.slot == 4
+    assert timer.active is True
+    assert timer.hour == 18
+    assert timer.minute == 38
+    assert timer.repeat_mask == 0xF6  # All days except bit 0 and 3
+    assert timer.action_type == TIMER_ACTION_SCENE_GRADIENT
+    assert len(timer.colors) == 5
+    # First color: 0c 64 64 = (12, 100, 100)
+    assert timer.colors[0] == (0x0C, 0x64, 0x64)
+
+
+def test_led_timer_extended_from_bytes_scene_segments():
+    """Test LedTimerExtended.from_bytes for scene segments timer."""
+    # Scene segments timer: slot=1, 12:00, e1 22 header, 3 colors
+    # Construct a minimal segments timer
+    data = bytearray()
+    data.append(0x01)  # slot
+    data.append(0xF0)  # flags
+    data.append(12)  # hour
+    data.append(0)  # minute
+    data.append(0)  # seconds
+    data.append(0)  # repeat
+    data.append(0x6B)  # action (segments)
+    data.append(0xE1)  # effect marker
+    data.append(0x22)  # segments type
+    data.extend([0, 0, 0, 0])  # header padding
+    data.append(3)  # num colors
+    # 3 colors (5 bytes each)
+    data.extend([100, 100, 50, 0, 0])
+    data.extend([50, 80, 60, 0, 0])
+    data.extend([150, 90, 70, 0, 0])
+
+    timer, _consumed = LedTimerExtended.from_bytes(bytes(data), 0)
+
+    assert timer.slot == 1
+    assert timer.active is True
+    assert timer.action_type == TIMER_ACTION_SCENE_SEGMENTS
+    assert len(timer.colors) == 3
+    assert timer.colors[0] == (100, 100, 50)
+    assert timer.colors[1] == (50, 80, 60)
+    assert timer.colors[2] == (150, 90, 70)
+
+
+def test_led_timer_extended_str_unknown_action():
+    """Test LedTimerExtended.__str__ for unknown action type."""
+    timer = LedTimerExtended(
+        slot=1,
+        active=True,
+        hour=10,
+        minute=30,
+        action_type=0xFF,  # Unknown action
+    )
+
+    s = str(timer)
+    assert "Unknown action: 0xff" in s
+
+
+def test_led_timer_extended_from_bytes_truncated():
+    """Test LedTimerExtended.from_bytes handles truncated data."""
+    # Only 5 bytes - not enough for a valid timer
+    data = bytes([0x01, 0xF0, 12, 30, 0])
+    _timer, consumed = LedTimerExtended.from_bytes(data, 0)
+    assert consumed == 5  # Returns what's available

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -4360,10 +4360,7 @@ def test_protocol_extended_custom_state_response_length():
 
 def test_protocol_extended_state_validation_0xB6():
     """The protocols recognise the extended (0xEA 0x81) state response."""
-    ext = bytes(
-        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
-        + (0x00, 0x00, 0x00, 0x64, 0x64, 0x00, 0x00, 0x00, 0x00, 0x83)
-    )
+    ext = bytes.fromhex("ea810100b605236100640f00000064640000000083")
     # ProtocolLEDENET8Byte (used while probing) recognises the extended frame.
     assert ProtocolLEDENET8Byte().is_valid_extended_state_response(ext) is True
     # The dedicated protocol only accepts the extended format.
@@ -4374,21 +4371,43 @@ def test_protocol_extended_state_validation_0xB6():
 
 def test_protocol_extended_state_to_state_white_off():
     """white_brightness of 0 maps to both white channels off."""
-    ext = bytes(
-        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
-        + (0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x83)
-    )
+    ext = bytes.fromhex("ea810100b605236100640f000000ff000000000083")
     result = ProtocolLEDENETExtendedCustom().extended_state_to_state(ext)
     assert result[9] == 0  # warm_white
     assert result[11] == 0  # cool_white
 
 
+def test_protocol_extended_state_to_state_too_short_returns_empty():
+    """A truncated extended frame (< 20 bytes) returns an empty bytestring."""
+    proto = ProtocolLEDENETExtendedCustom()
+    assert proto.extended_state_to_state(b"\xea\x81\x01\x00\xb6") == b""
+
+
 def test_protocol_named_raw_state_extended_conversion():
     """named_raw_state converts an extended frame to the standard layout."""
-    ext = bytes(
-        (0xEA, 0x81, 0x01, 0x00, 0xB6, 0x05, 0x23, 0x61, 0x00, 0x64, 0x0F)
-        + (0x00, 0x00, 0x00, 0x64, 0x64, 0x00, 0x00, 0x00, 0x00, 0x83)
-    )
+    ext = bytes.fromhex("ea810100b605236100640f00000064640000000083")
     result = ProtocolLEDENETExtendedCustom().named_raw_state(ext)
     assert result.head == 0x81
     assert result.model_num == 0xB6
+
+
+def test_extended_state_led_count():
+    """extended_state_led_count returns the configured LED count from real captured frames.
+
+    Real captured frames (0xB6 device):
+      LED count = 100: ea 81 01 00 b6 09 24 66 01 64 f0 00 00 00 00 64 05 00 64 00 00 00 20 02 01 00 03
+      LED count =  80: ea 81 01 00 b6 09 23 66 01 64 f0 00 00 00 00 64 05 00 50 00 00 00 20 02 01 00 03
+
+    The LED count byte is at index 18 of the raw extended state buffer.
+    """
+    proto = ProtocolLEDENETExtendedCustom()
+
+    frame_100 = bytes.fromhex("ea810100b60924660164f000000000640500640000002002010003")
+    frame_80 = bytes.fromhex("ea810100b60923660164f000000000640500500000002002010003")
+
+    assert proto.extended_state_led_count(frame_100) == 100
+    assert proto.extended_state_led_count(frame_80) == 80
+
+    # Too-short / invalid frame returns None
+    assert proto.extended_state_led_count(b"\xea\x81\x01") is None
+    assert proto.extended_state_led_count(b"\x00" * 27) is None

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -40,7 +40,12 @@ from flux_led.const import (
     ScribbleLED,
     WhiteChannelType,
 )
-from flux_led.fluxled import processSetTimerArgs, processSetTimerArgsExtended
+from flux_led.fluxled import (
+    _reconcile_scribble_led_count,
+    processCustomArgs,
+    processSetTimerArgs,
+    processSetTimerArgsExtended,
+)
 from flux_led.protocol import (
     LEDENET_EXTENDED_STATE_RESPONSE_LEN,
     PROTOCOL_LEDENET_8BYTE_AUTO_ON,
@@ -6408,3 +6413,213 @@ def test_led_timer_standard_str_color():
     assert "19:00" in s
     assert "Sa" in s
     assert "Su" in s
+
+
+# ---------------------------------------------------------------------------
+# CLI scribble parsing tests (PR5)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_scribble_run_length_expansion():
+    """processCustomArgs scribble: '10xred 10xgreen 60xoff' -> 80 ScribbleLEDs."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "10xred 10xgreen 60xoff"))
+    assert result is not None
+    assert result["mode"] == "scribble"
+    assert result["effect"] == ScribbleEffect.STATIC.value
+    leds = result["leds"]
+    assert len(leds) == 80
+    # first 10: red
+    for led in leds[:10]:
+        assert led.rgb == (255, 0, 0)
+        assert led.white is None
+    # next 10: green
+    for led in leds[10:20]:
+        assert led.rgb == (0, 128, 0) or led.rgb == (0, 255, 0) or led.rgb[0] == 0
+        assert led.white is None
+    # last 60: off
+    for led in leds[20:]:
+        assert led.rgb is None
+        assert led.white is None
+
+
+def test_cli_scribble_white_led():
+    """processCustomArgs scribble: 'w100' -> one white LED with white=100."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "w100"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].rgb is None
+    assert leds[0].white == 100
+
+
+def test_cli_scribble_plain_red():
+    """processCustomArgs scribble: 'red' -> one red ScribbleLED."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "red"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].rgb is not None
+    assert leds[0].rgb[0] == 255  # red channel
+    assert leds[0].white is None
+
+
+def test_cli_scribble_off_led():
+    """processCustomArgs scribble: 'off' -> one off ScribbleLED."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "off"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].rgb is None
+    assert leds[0].white is None
+
+
+def test_cli_scribble_malformed_token():
+    """processCustomArgs scribble: malformed token -> parser.error called."""
+    parser = OptionParser()
+    with pytest.raises(SystemExit):
+        processCustomArgs(parser, ("scribble", "static", "notacolor!!!"))
+
+
+def test_cli_scribble_trailing_kvargs():
+    """processCustomArgs scribble: trailing key=value args are parsed correctly."""
+    parser = OptionParser()
+    result = processCustomArgs(
+        parser,
+        ("scribble", "flowing", "5xred speed=50 dir=r2l blink=fast blinkspeed=75"),
+    )
+    assert result is not None
+    assert result["mode"] == "scribble"
+    assert result["effect"] == ScribbleEffect.FLOWING.value
+    assert result["speed"] == 50
+    assert result["direction"] == ExtendedCustomEffectDirection.RIGHT_TO_LEFT.value
+    leds = result["leds"]
+    assert len(leds) == 5
+    # blink=fast and blinkspeed=75 should be baked into each LED
+    for led in leds:
+        assert led.blink_mode == ScribbleBlinkMode.FAST
+        assert led.blink_speed == 75
+
+
+def test_cli_scribble_effect_mapping():
+    """processCustomArgs scribble: all effect names map correctly."""
+    parser = OptionParser()
+    effect_map = {
+        "static": ScribbleEffect.STATIC.value,
+        "flowing": ScribbleEffect.FLOWING.value,
+        "twinkling": ScribbleEffect.TWINKLING_STARS.value,
+        "stars_wink": ScribbleEffect.STARS_WINK.value,
+        "accumulate": ScribbleEffect.ACCUMULATE.value,
+    }
+    for name, expected_value in effect_map.items():
+        result = processCustomArgs(parser, ("scribble", name, "red"))
+        assert result is not None, f"Failed for effect {name}"
+        assert result["effect"] == expected_value, f"Wrong value for effect {name}"
+
+
+def test_cli_scribble_white_run_length():
+    """processCustomArgs scribble: '3xw50' -> 3 white LEDs at level 50."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "3xw50"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 3
+    for led in leds:
+        assert led.rgb is None
+        assert led.white == 50
+
+
+def test_cli_scribble_off_run_length():
+    """processCustomArgs scribble: '5xoff' -> 5 off ScribbleLEDs."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "5xoff"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 5
+    for led in leds:
+        assert led.rgb is None
+        assert led.white is None
+
+
+def test_cli_scribble_default_fields():
+    """processCustomArgs scribble: returned dict has density and direction defaults."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "red"))
+    assert result is not None
+    assert "density" in result
+    assert "direction" in result
+    assert result["density"] == 80
+    assert result["direction"] == ExtendedCustomEffectDirection.LEFT_TO_RIGHT.value
+
+
+def test_cli_scribble_color_name_starting_with_w():
+    """processCustomArgs scribble: 'white' parses to a color LED, not a white-level token."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "white"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].rgb == (255, 255, 255)
+    assert leds[0].white is None
+
+
+def test_cli_scribble_wheat_color_name():
+    """processCustomArgs scribble: 'wheat' parses as a color LED (not a white token)."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "wheat"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].rgb is not None
+    assert leds[0].white is None
+
+
+def test_cli_scribble_white_level_still_works():
+    """processCustomArgs scribble: 'w50' still parses as white level 50."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "w50"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].rgb is None
+    assert leds[0].white == 50
+
+
+def test_reconcile_scribble_led_count_pad():
+    """_reconcile_scribble_led_count pads the tail with off-LEDs to reach device count."""
+    leds = [ScribbleLED(rgb=(255, 0, 0))] * 10
+    result = _reconcile_scribble_led_count(leds, 80)
+    assert len(result) == 80
+    # first 10 keep the red color
+    for led in result[:10]:
+        assert led.rgb == (255, 0, 0)
+    # remaining 70 are off
+    for led in result[10:]:
+        assert led.rgb is None
+        assert led.white is None
+
+
+def test_reconcile_scribble_led_count_truncate():
+    """_reconcile_scribble_led_count truncates to device count when too many."""
+    leds = [ScribbleLED(rgb=(0, 0, 255))] * 90
+    result = _reconcile_scribble_led_count(leds, 80)
+    assert len(result) == 80
+    for led in result:
+        assert led.rgb == (0, 0, 255)
+
+
+def test_reconcile_scribble_led_count_none_device():
+    """_reconcile_scribble_led_count returns leds unchanged when device count is None."""
+    leds = [ScribbleLED(rgb=(0, 255, 0))] * 5
+    result = _reconcile_scribble_led_count(leds, None)
+    assert result is leds
+
+
+def test_reconcile_scribble_led_count_exact_match():
+    """_reconcile_scribble_led_count returns leds unchanged when count matches."""
+    leds = [ScribbleLED(rgb=(0, 255, 0))] * 80
+    result = _reconcile_scribble_led_count(leds, 80)
+    assert len(result) == 80

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import colorsys
 import contextlib
 import datetime
 import json
@@ -24,6 +25,9 @@ from flux_led.const import (
     MAX_TEMP,
     MIN_TEMP,
     PUSH_UPDATE_INTERVAL,
+    ExtendedCustomEffectDirection,
+    ExtendedCustomEffectOption,
+    ExtendedCustomEffectPattern,
     MultiColorEffects,
     WhiteChannelType,
 )
@@ -4411,3 +4415,901 @@ def test_extended_state_led_count():
     # Too-short / invalid frame returns None
     assert proto.extended_state_led_count(b"\xea\x81\x01") is None
     assert proto.extended_state_led_count(b"\x00" * 27) is None
+def test_extended_custom_effect_pattern_enum_values():
+    """Test ExtendedCustomEffectPattern enum has expected values."""
+    assert ExtendedCustomEffectPattern.WAVE.value == 0x01
+    assert ExtendedCustomEffectPattern.METEOR.value == 0x02
+    assert ExtendedCustomEffectPattern.STREAMER.value == 0x03
+    assert ExtendedCustomEffectPattern.BUILDING_BLOCKS.value == 0x04
+    assert ExtendedCustomEffectPattern.BREATHE.value == 0x09
+    assert ExtendedCustomEffectPattern.STATIC_GRADIENT.value == 0x65
+    assert ExtendedCustomEffectPattern.STATIC_FILL.value == 0x66
+
+
+def test_extended_custom_effect_direction_enum_values():
+    """Test ExtendedCustomEffectDirection enum has expected values."""
+    assert ExtendedCustomEffectDirection.LEFT_TO_RIGHT.value == 0x01
+    assert ExtendedCustomEffectDirection.RIGHT_TO_LEFT.value == 0x02
+
+
+def test_extended_custom_effect_option_enum_values():
+    """Test ExtendedCustomEffectOption enum has expected values."""
+    assert ExtendedCustomEffectOption.DEFAULT.value == 0x00
+    assert ExtendedCustomEffectOption.VARIANT_1.value == 0x01
+    assert ExtendedCustomEffectOption.VARIANT_2.value == 0x02
+
+
+def test_construct_extended_custom_effect_single_color():
+    """Test constructing an extended custom effect with single color."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Single red color, pattern Wave, default settings
+    result = proto.construct_extended_custom_effect(
+        pattern_id=1,
+        colors=[(255, 0, 0)],
+        speed=50,
+        density=50,
+        direction=0x01,
+        option=0x00,
+    )
+
+    # Result should be a wrapped message
+    assert isinstance(result, bytearray)
+    assert len(result) > 0
+
+    # Check the wrapper header (b0 b1 b2 b3)
+    assert result[0] == 0xB0
+    assert result[1] == 0xB1
+    assert result[2] == 0xB2
+    assert result[3] == 0xB3
+
+
+def test_construct_extended_custom_effect_multiple_colors():
+    """Test constructing an extended custom effect with multiple colors."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Three colors: red, green, blue
+    colors = [(255, 0, 0), (0, 255, 0), (0, 0, 255)]
+    result = proto.construct_extended_custom_effect(
+        pattern_id=2,  # Meteor
+        colors=colors,
+        speed=80,
+        density=100,
+        direction=0x02,  # Right to Left
+        option=0x01,  # Color change
+    )
+
+    assert isinstance(result, bytearray)
+    assert len(result) > 0
+
+
+def test_construct_extended_custom_effect_color_order():
+    """Test that colors are stored in input order."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Two distinct colors
+    colors = [(255, 0, 0), (0, 0, 255)]  # Red, Blue
+    result = proto.construct_extended_custom_effect(
+        pattern_id=1,
+        colors=colors,
+        speed=50,
+        density=50,
+    )
+
+    # The message structure after wrapper:
+    # Inner message starts after wrapper header + length bytes
+    # Find the color data section (after the 16-byte header)
+    # Colors are 5 bytes each (H, S, V, 0, 0) in input order
+
+    # Red (255, 0, 0) in HSV: H=0, S=100, V=100 -> stored as (0, 100, 100)
+    # Blue (0, 0, 255) in HSV: H=240, S=100, V=100 -> stored as (120, 100, 100)
+
+    # Red should come first in the message (same order as input)
+    assert isinstance(result, bytearray)
+
+
+def test_construct_extended_custom_effect_hsv_conversion():
+    """Test RGB to HSV conversion accuracy."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test with a known color: pure green
+    colors = [(0, 255, 0)]
+    result = proto.construct_extended_custom_effect(
+        pattern_id=1,
+        colors=colors,
+    )
+
+    # Green in HSV: H=120, S=100%, V=100%
+    # Stored as: H/2=60, S=100, V=100
+    # Verify the message was constructed
+    assert isinstance(result, bytearray)
+    assert len(result) > 0
+
+
+def test_construct_extended_custom_effect_speed_clamping():
+    """Test that speed is clamped to 0-100."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Speed > 100 should be clamped
+    result = proto.construct_extended_custom_effect(
+        pattern_id=1,
+        colors=[(255, 0, 0)],
+        speed=150,
+    )
+    assert isinstance(result, bytearray)
+
+    # Speed < 0 should be clamped
+    result = proto.construct_extended_custom_effect(
+        pattern_id=1,
+        colors=[(255, 0, 0)],
+        speed=-10,
+    )
+    assert isinstance(result, bytearray)
+
+
+def test_construct_extended_custom_effect_density_clamping():
+    """Test that density is clamped to 0-100."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Density > 100 should be clamped
+    result = proto.construct_extended_custom_effect(
+        pattern_id=1,
+        colors=[(255, 0, 0)],
+        density=200,
+    )
+    assert isinstance(result, bytearray)
+
+
+def test_construct_extended_custom_effect_max_colors():
+    """Test constructing an effect with maximum 8 colors."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # 8 colors (maximum)
+    colors = [
+        (255, 0, 0),
+        (255, 128, 0),
+        (255, 255, 0),
+        (0, 255, 0),
+        (0, 255, 255),
+        (0, 0, 255),
+        (128, 0, 255),
+        (255, 0, 255),
+    ]
+    result = proto.construct_extended_custom_effect(
+        pattern_id=1,
+        colors=colors,
+    )
+
+    assert isinstance(result, bytearray)
+    # Each color is 5 bytes, 8 colors = 40 bytes for colors
+    # Plus 16 bytes header = 56 bytes inner message
+    # Plus wrapper overhead
+
+
+def test_construct_extended_custom_effect_with_enums():
+    """Test using enum values for parameters."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    result = proto.construct_extended_custom_effect(
+        pattern_id=ExtendedCustomEffectPattern.WAVE,
+        colors=[(255, 0, 0)],
+        speed=50,
+        density=50,
+        direction=ExtendedCustomEffectDirection.RIGHT_TO_LEFT,
+        option=ExtendedCustomEffectOption.VARIANT_1,
+    )
+
+    assert isinstance(result, bytearray)
+
+
+def test_construct_extended_custom_effect_with_variant_2():
+    """Test using VARIANT_2 option (e.g., breathe mode for rainbow patterns)."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Rainbow colors with VARIANT_2 option
+    colors = [
+        (255, 0, 0),  # Red
+        (255, 255, 0),  # Yellow
+        (0, 255, 0),  # Green
+        (0, 255, 255),  # Cyan
+        (0, 0, 255),  # Blue
+        (255, 0, 255),  # Magenta
+    ]
+    result = proto.construct_extended_custom_effect(
+        pattern_id=12,  # Twinkling stars
+        colors=colors,
+        speed=60,
+        density=100,
+        direction=ExtendedCustomEffectDirection.LEFT_TO_RIGHT,
+        option=ExtendedCustomEffectOption.VARIANT_2,
+    )
+
+    assert isinstance(result, bytearray)
+    assert len(result) > 0
+
+
+def test_extended_custom_effect_hsv_values():
+    """Test specific HSV value calculations."""
+    # Test the HSV conversion formula used in the protocol
+    # RGB (255, 0, 0) -> HSV (0, 100%, 100%) -> stored as (0, 100, 100)
+    r, g, b = 255, 0, 0
+    h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+    hsv_h = int(h * 180)
+    hsv_s = int(s * 100)
+    hsv_v = int(v * 100)
+
+    assert hsv_h == 0  # Red hue
+    assert hsv_s == 100  # Full saturation
+    assert hsv_v == 100  # Full value
+
+    # RGB (0, 0, 255) -> HSV (240, 100%, 100%) -> stored as (120, 100, 100)
+    r, g, b = 0, 0, 255
+    h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+    hsv_h = int(h * 180)
+    hsv_s = int(s * 100)
+    hsv_v = int(v * 100)
+
+    assert hsv_h == 120  # Blue hue (240/2)
+    assert hsv_s == 100
+    assert hsv_v == 100
+
+    # RGB (0, 255, 0) -> HSV (120, 100%, 100%) -> stored as (60, 100, 100)
+    r, g, b = 0, 255, 0
+    h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+    hsv_h = int(h * 180)
+    hsv_s = int(s * 100)
+    hsv_v = int(v * 100)
+
+    assert hsv_h == 60  # Green hue (120/2)
+    assert hsv_s == 100
+    assert hsv_v == 100
+
+
+# Tests for _generate_extended_custom_effect validation (base_device.py lines 1335-1360)
+
+
+@pytest.mark.asyncio
+async def test_generate_extended_custom_effect_validation(mock_aio_protocol):
+    """Test validation in _generate_extended_custom_effect."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    await mock_aio_protocol()
+
+    # Setup 0xB6 device with extended state
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    assert light.protocol == PROTOCOL_LEDENET_EXTENDED_CUSTOM
+
+    # Test invalid pattern_id (0 is not valid)
+    with pytest.raises(ValueError, match="Pattern ID must be 1-24 or 101-102"):
+        light._generate_extended_custom_effect(0, [(255, 0, 0)])
+
+    # Test invalid pattern_id (25 is not valid)
+    with pytest.raises(ValueError, match="Pattern ID must be 1-24 or 101-102"):
+        light._generate_extended_custom_effect(25, [(255, 0, 0)])
+
+    # Test empty colors list
+    with pytest.raises(ValueError, match="at least one color"):
+        light._generate_extended_custom_effect(1, [])
+
+    # Test invalid color tuple (not 3 elements)
+    with pytest.raises(ValueError, match=r"must be .* tuple"):
+        light._generate_extended_custom_effect(1, [(255, 0)])
+
+    # Test color values out of range (> 255)
+    with pytest.raises(ValueError, match="must be 0-255"):
+        light._generate_extended_custom_effect(1, [(256, 0, 0)])
+
+    # Test color values out of range (< 0)
+    with pytest.raises(ValueError, match="must be 0-255"):
+        light._generate_extended_custom_effect(1, [(-1, 0, 0)])
+
+    # Test valid pattern_id 101 (STATIC_GRADIENT)
+    result = light._generate_extended_custom_effect(101, [(255, 0, 0)])
+    assert isinstance(result, bytearray)
+
+    # Test valid pattern_id 102 (STATIC_FILL)
+    result = light._generate_extended_custom_effect(102, [(255, 0, 0)])
+    assert isinstance(result, bytearray)
+
+
+@pytest.mark.asyncio
+async def test_generate_extended_custom_effect_truncate_colors(
+    mock_aio_protocol, caplog: pytest.LogCaptureFixture
+):
+    """Test that too many colors (>8) are truncated with warning."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    await mock_aio_protocol()
+
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    # 10 colors (more than 8 max)
+    colors = [(i * 25, 0, 0) for i in range(10)]
+
+    with caplog.at_level(logging.WARNING):
+        result = light._generate_extended_custom_effect(1, colors)
+
+    assert isinstance(result, bytearray)
+    assert "truncating" in caplog.text.lower()
+
+
+# Tests for _generate_custom_segment_colors validation (base_device.py lines 1376-1392)
+
+
+@pytest.mark.asyncio
+async def test_generate_custom_segment_colors_validation(mock_aio_protocol):
+    """Test validation in _generate_custom_segment_colors."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    await mock_aio_protocol()
+
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    # Test invalid color tuple (not 3 elements)
+    with pytest.raises(ValueError, match=r"must be .* tuple"):
+        light._generate_custom_segment_colors([(255, 0)])
+
+    # Test color values out of range (> 255)
+    with pytest.raises(ValueError, match="must be 0-255"):
+        light._generate_custom_segment_colors([(256, 0, 0)])
+
+    # Test valid segments with None
+    result = light._generate_custom_segment_colors([None, (255, 0, 0), None])
+    assert isinstance(result, bytearray)
+
+
+@pytest.mark.asyncio
+async def test_generate_custom_segment_colors_truncate(
+    mock_aio_protocol, caplog: pytest.LogCaptureFixture
+):
+    """Test that too many segments (>20) are truncated with warning."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    await mock_aio_protocol()
+
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    # 25 segments (more than 20 max)
+    segments = [(i * 10, 0, 0) for i in range(25)]
+
+    with caplog.at_level(logging.WARNING):
+        result = light._generate_custom_segment_colors(segments)
+
+    assert isinstance(result, bytearray)
+    assert "truncating" in caplog.text.lower()
+
+
+# Tests for construct_levels_change (protocol.py lines 1826-1861)
+
+
+def test_protocol_construct_levels_change_0xB6():
+    """Test construct_levels_change uses STATIC_FILL for 0xB6 protocol."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test with RGB values
+    result = proto.construct_levels_change(
+        persist=1,
+        red=255,
+        green=0,
+        blue=0,
+        warm_white=0,
+        cool_white=0,
+        write_mode=0,
+    )
+
+    assert len(result) == 1
+    msg = result[0]
+    assert isinstance(msg, bytearray)
+    # Check wrapper header
+    assert msg[0] == 0xB0
+    assert msg[1] == 0xB1
+    assert msg[2] == 0xB2
+    assert msg[3] == 0xB3
+
+
+def test_protocol_construct_levels_change_with_white():
+    """Test construct_levels_change combines warm and cool white."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test with white values
+    result = proto.construct_levels_change(
+        persist=1,
+        red=0,
+        green=0,
+        blue=0,
+        warm_white=100,
+        cool_white=50,
+        write_mode=0,
+    )
+
+    assert len(result) == 1
+    msg = result[0]
+    assert isinstance(msg, bytearray)
+
+
+def test_protocol_construct_levels_change_white_clamping():
+    """Test that combined white is clamped to 255."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test with white values that exceed 255 when combined
+    result = proto.construct_levels_change(
+        persist=1,
+        red=0,
+        green=0,
+        blue=0,
+        warm_white=200,
+        cool_white=200,  # Total would be 400, should clamp to 255
+        write_mode=0,
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], bytearray)
+
+
+def test_protocol_rgb_to_hsv_bytes_rgbw():
+    """Test _rgb_to_hsv_bytes_rgbw conversion."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test pure red with white
+    result = proto._rgb_to_hsv_bytes_rgbw(255, 0, 0, 100)
+    assert len(result) == 5
+    assert result[0] == 0  # Hue (red = 0)
+    assert result[1] == 100  # Saturation
+    assert result[2] == 100  # Value
+    assert result[3] == 0x00  # Unused
+    assert result[4] == 100  # White
+
+    # Test pure green
+    result = proto._rgb_to_hsv_bytes_rgbw(0, 255, 0, 0)
+    assert result[0] == 60  # Hue (green = 120/2)
+
+    # Test pure blue
+    result = proto._rgb_to_hsv_bytes_rgbw(0, 0, 255, 255)
+    assert result[0] == 120  # Hue (blue = 240/2)
+    assert result[4] == 255  # White
+
+
+# Tests for construct_custom_segment_colors (protocol.py lines 1971-1980)
+
+
+def test_protocol_construct_custom_segment_colors():
+    """Test construct_custom_segment_colors command format."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test with a few segments
+    segments = [(255, 0, 0), None, (0, 255, 0)]
+    result = proto.construct_custom_segment_colors(segments)
+
+    assert isinstance(result, bytearray)
+    # Check wrapper header
+    assert result[0] == 0xB0
+    assert result[1] == 0xB1
+    assert result[2] == 0xB2
+    assert result[3] == 0xB3
+
+
+def test_protocol_construct_custom_segment_colors_all_off():
+    """Test construct_custom_segment_colors with all segments off."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # All None segments
+    segments = [None] * 10
+    result = proto.construct_custom_segment_colors(segments)
+
+    assert isinstance(result, bytearray)
+
+
+def test_protocol_construct_custom_segment_colors_zero_tuple():
+    """Test that (0,0,0) is treated as off."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Mix of None and (0,0,0)
+    segments = [None, (0, 0, 0), (255, 0, 0)]
+    result = proto.construct_custom_segment_colors(segments)
+
+    assert isinstance(result, bytearray)
+
+
+# Tests for async API methods
+
+
+@pytest.mark.asyncio
+async def test_async_set_extended_custom_effect_0xB6(mock_aio_protocol):
+    """Test async_set_extended_custom_effect sends correct bytes."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, _protocol = await mock_aio_protocol()
+
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    transport.reset_mock()
+
+    await light.async_set_extended_custom_effect(
+        pattern_id=1,
+        colors=[(255, 0, 0), (0, 255, 0)],
+        speed=50,
+        density=50,
+    )
+
+    assert transport.write.called
+    written_data = transport.write.call_args[0][0]
+    # Verify it's a wrapped message
+    assert written_data[0] == 0xB0
+    assert written_data[1] == 0xB1
+
+
+@pytest.mark.asyncio
+async def test_async_set_custom_segment_colors_0xB6(mock_aio_protocol):
+    """Test async_set_custom_segment_colors sends correct bytes."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, _protocol = await mock_aio_protocol()
+
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    transport.reset_mock()
+
+    await light.async_set_custom_segment_colors(
+        segments=[(255, 0, 0), None, (0, 0, 255)]
+    )
+
+    assert transport.write.called
+    written_data = transport.write.call_args[0][0]
+    # Verify it's a wrapped message
+    assert written_data[0] == 0xB0
+    assert written_data[1] == 0xB1
+
+
+# Tests for extended_custom_effect_pattern_list property (base_device.py line 658)
+
+
+@pytest.mark.asyncio
+async def test_extended_custom_effect_pattern_list_0xB6(mock_aio_protocol):
+    """Test extended_custom_effect_pattern_list returns list for 0xB6 device."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    await mock_aio_protocol()
+
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    # Test extended_custom_effect_pattern_list returns a list
+    pattern_list = light.extended_custom_effect_pattern_list
+    assert pattern_list is not None
+    assert isinstance(pattern_list, list)
+    assert len(pattern_list) > 0
+    # Check some expected patterns
+    assert "wave" in pattern_list
+    assert "meteor" in pattern_list
+    assert "breathe" in pattern_list
+
+
+@pytest.mark.asyncio
+async def test_extended_custom_effect_pattern_list_non_0xB6(mock_aio_protocol):
+    """Test extended_custom_effect_pattern_list returns None for non-0xB6 device."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    await mock_aio_protocol()
+
+    # Standard 0x25 device (not extended custom)
+    light._aio_protocol.data_received(
+        b"\x81\x25\x23\x61\x05\x10\xb6\x00\x98\x19\x04\x25\x0f\xde"
+    )
+    await task
+
+    # Should return None for non-extended devices
+    assert light.extended_custom_effect_pattern_list is None
+
+
+# Tests for _named_effect with extended custom effects (base_device.py line 676)
+
+
+@pytest.mark.asyncio
+async def test_named_effect_extended_custom_0xB6(mock_aio_protocol):
+    """Test _named_effect returns extended effect name for 0xB6 in custom mode."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    await mock_aio_protocol()
+
+    # 0xB6 device with preset_pattern=0x25 (custom effect mode) and mode=0x01 (Wave)
+    # Extended state: preset_pattern at pos 7, mode at pos 8
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,  # Model
+                0x01,  # Version
+                0x23,  # Power on
+                0x25,  # preset_pattern = 0x25 (custom effect mode)
+                0x01,  # mode = Wave pattern ID
+                0x64,  # speed
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    # Effect should be "Wave" from EXTENDED_CUSTOM_EFFECT_ID_NAME
+    assert light.effect == "Wave"
+
+
+@pytest.mark.asyncio
+async def test_named_effect_extended_custom_meteor(mock_aio_protocol):
+    """Test _named_effect returns Meteor for mode=0x02."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    await mock_aio_protocol()
+
+    # 0xB6 device with mode=0x02 (Meteor)
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x25,  # preset_pattern = 0x25
+                0x02,  # mode = Meteor
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    assert light.effect == "Meteor"

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -6187,7 +6187,6 @@ def test_led_timer_extended_from_bytes_truncated():
     assert consumed == 5  # Returns what's available
 
 
-
 def test_cli_process_set_timer_args_extended_inactive():
     """Test CLI parsing for inactive extended timer."""
     parser = OptionParser()
@@ -6623,3 +6622,255 @@ def test_reconcile_scribble_led_count_exact_match():
     leds = [ScribbleLED(rgb=(0, 255, 0))] * 80
     result = _reconcile_scribble_led_count(leds, 80)
     assert len(result) == 80
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — Numeric effect id
+# ---------------------------------------------------------------------------
+
+
+def test_cli_scribble_numeric_effect_valid():
+    """processCustomArgs scribble: numeric effect id 4 -> effect==4 in result."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "4", "80xred"))
+    assert result is not None
+    assert result["mode"] == "scribble"
+    assert result["effect"] == 4
+
+
+def test_cli_scribble_numeric_effect_zero():
+    """processCustomArgs scribble: numeric effect id 0 -> effect==0 (same as static)."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "0", "red"))
+    assert result is not None
+    assert result["effect"] == 0
+
+
+def test_cli_scribble_numeric_effect_max():
+    """processCustomArgs scribble: numeric effect id 8 -> effect==8 (same as accumulate)."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "8", "red"))
+    assert result is not None
+    assert result["effect"] == 8
+
+
+def test_cli_scribble_named_effect_still_works():
+    """processCustomArgs scribble: named effect 'flowing' -> effect==1."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "flowing", "red"))
+    assert result is not None
+    assert result["effect"] == ScribbleEffect.FLOWING.value
+
+
+def test_cli_scribble_numeric_effect_out_of_range():
+    """processCustomArgs scribble: effect id 9 -> parser.error (SystemExit)."""
+    parser = OptionParser()
+    with pytest.raises(SystemExit):
+        processCustomArgs(parser, ("scribble", "9", "red"))
+
+
+def test_cli_scribble_numeric_effect_garbage():
+    """processCustomArgs scribble: garbage effect name -> parser.error (SystemExit)."""
+    parser = OptionParser()
+    with pytest.raises(SystemExit):
+        processCustomArgs(parser, ("scribble", "boguseffect", "red"))
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 — Per-LED blink syntax  (<value>[/<blinkmode>[/<blinkspeed>]])
+# ---------------------------------------------------------------------------
+
+
+def test_cli_scribble_per_led_blink_suffix_fast():
+    """processCustomArgs scribble: 'red/fast/80' -> FAST blink_mode, speed 80."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "red/fast/80"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].blink_mode == ScribbleBlinkMode.FAST
+    assert leds[0].blink_speed == 80
+
+
+def test_cli_scribble_per_led_blink_suffix_run_length():
+    """processCustomArgs scribble: '40xred/fast/80 40xgreen' -> first 40 FAST, last 40 NONE."""
+    parser = OptionParser()
+    result = processCustomArgs(
+        parser, ("scribble", "static", "40xred/fast/80 40xgreen")
+    )
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 80
+    for led in leds[:40]:
+        assert led.blink_mode == ScribbleBlinkMode.FAST
+        assert led.blink_speed == 80
+    for led in leds[40:]:
+        assert led.blink_mode == ScribbleBlinkMode.NONE
+
+
+def test_cli_scribble_per_led_blink_suffix_white():
+    """processCustomArgs scribble: 'w50/slow' -> white=50 with SLOW blink."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "w50/slow"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].white == 50
+    assert leds[0].blink_mode == ScribbleBlinkMode.SLOW
+
+
+def test_cli_scribble_per_led_blink_suffix_off():
+    """processCustomArgs scribble: 'off/fast' -> off LED with FAST blink."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "off/fast"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].rgb is None
+    assert leds[0].white is None
+    assert leds[0].blink_mode == ScribbleBlinkMode.FAST
+
+
+def test_cli_scribble_per_led_blink_overrides_global():
+    """processCustomArgs scribble: per-token blink overrides global blink= setting."""
+    parser = OptionParser()
+    result = processCustomArgs(
+        parser,
+        ("scribble", "static", "red/fast/80 blue blink=slow blinkspeed=30"),
+    )
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 2
+    # 'red/fast/80' overrides global
+    assert leds[0].blink_mode == ScribbleBlinkMode.FAST
+    assert leds[0].blink_speed == 80
+    # 'blue' inherits global blink=slow blinkspeed=30
+    assert leds[1].blink_mode == ScribbleBlinkMode.SLOW
+    assert leds[1].blink_speed == 30
+
+
+def test_cli_scribble_per_led_blink_mode_only():
+    """processCustomArgs scribble: 'green/slow' -> SLOW blink, default speed."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "green/slow"))
+    assert result is not None
+    leds = result["leds"]
+    assert len(leds) == 1
+    assert leds[0].blink_mode == ScribbleBlinkMode.SLOW
+
+
+def test_cli_scribble_per_led_blink_bogus_mode():
+    """processCustomArgs scribble: 'red/bogus' -> parser.error (SystemExit)."""
+    parser = OptionParser()
+    with pytest.raises(SystemExit):
+        processCustomArgs(parser, ("scribble", "static", "red/bogus"))
+
+
+# ---------------------------------------------------------------------------
+# Gap 3 — enter=true|false token
+# ---------------------------------------------------------------------------
+
+
+def test_cli_scribble_enter_false():
+    """processCustomArgs scribble: 'enter=false' -> enter_mode False in result."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "80xred enter=false"))
+    assert result is not None
+    assert result["enter_mode"] is False
+
+
+def test_cli_scribble_enter_true_explicit():
+    """processCustomArgs scribble: 'enter=true' -> enter_mode True in result."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "red enter=true"))
+    assert result is not None
+    assert result["enter_mode"] is True
+
+
+def test_cli_scribble_enter_default_true():
+    """processCustomArgs scribble: absent enter= token -> enter_mode defaults to True."""
+    parser = OptionParser()
+    result = processCustomArgs(parser, ("scribble", "static", "red"))
+    assert result is not None
+    assert result["enter_mode"] is True
+
+
+def test_cli_scribble_enter_invalid():
+    """processCustomArgs scribble: 'enter=maybe' -> parser.error (SystemExit)."""
+    parser = OptionParser()
+    with pytest.raises(SystemExit):
+        processCustomArgs(parser, ("scribble", "static", "red enter=maybe"))
+
+
+# ---------------------------------------------------------------------------
+# Gap 4 — processCustomArgs variant parameter
+# ---------------------------------------------------------------------------
+
+
+def test_processCustomArgs_variant_2():
+    """processCustomArgs: variant=2 -> option==2 in extended result."""
+    parser = OptionParser()
+    result = processCustomArgs(
+        parser,
+        ("wave", "60", "red green"),
+        variant=2,
+    )
+    assert result is not None
+    assert result["mode"] == "extended"
+    assert result["option"] == 2
+
+
+def test_processCustomArgs_variant_1():
+    """processCustomArgs: variant=1 -> option==1."""
+    parser = OptionParser()
+    result = processCustomArgs(
+        parser,
+        ("wave", "60", "red green"),
+        variant=1,
+    )
+    assert result is not None
+    assert result["option"] == 1
+
+
+def test_processCustomArgs_variant_0():
+    """processCustomArgs: variant=0 -> option==0."""
+    parser = OptionParser()
+    result = processCustomArgs(
+        parser,
+        ("wave", "60", "red green"),
+        variant=0,
+    )
+    assert result is not None
+    assert result["option"] == 0
+
+
+def test_processCustomArgs_variant_out_of_range():
+    """processCustomArgs: variant=5 -> parser.error (SystemExit)."""
+    parser = OptionParser()
+    with pytest.raises(SystemExit):
+        processCustomArgs(parser, ("wave", "60", "red green"), variant=5)
+
+
+def test_processCustomArgs_colorchange_still_works():
+    """processCustomArgs: colorchange=True without variant -> option==1 (unchanged)."""
+    parser = OptionParser()
+    result = processCustomArgs(
+        parser,
+        ("wave", "60", "red green"),
+        colorchange=True,
+    )
+    assert result is not None
+    assert result["option"] == 1
+
+
+def test_processCustomArgs_variant_overrides_colorchange():
+    """processCustomArgs: variant=2 with colorchange=True -> option==2 (variant wins)."""
+    parser = OptionParser()
+    result = processCustomArgs(
+        parser,
+        ("wave", "60", "red green"),
+        colorchange=True,
+        variant=2,
+    )
+    assert result is not None
+    assert result["option"] == 2

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -33,6 +33,7 @@ from flux_led.protocol import (
     PROTOCOL_LEDENET_ADDRESSABLE_A1,
     PROTOCOL_LEDENET_ADDRESSABLE_A2,
     PROTOCOL_LEDENET_ADDRESSABLE_A3,
+    PROTOCOL_LEDENET_EXTENDED_CUSTOM,
     PROTOCOL_LEDENET_ORIGINAL,
     PROTOCOL_LEDENET_ORIGINAL_CCT,
     PROTOCOL_LEDENET_SOCKET,
@@ -1421,6 +1422,43 @@ class TestLight(unittest.TestCase):
 
         light.set_effect("colorloop", 50, 50)
         self.assertEqual(mock_send.call_args, mock.call(bytearray(b"8%\x102\x9f")))
+
+    @patch("flux_led.WifiLedBulb._send_msg")
+    @patch("flux_led.WifiLedBulb._read_msg")
+    @patch("flux_led.WifiLedBulb.connect")
+    def test_0xB6_surplife_sync(self, mock_connect, mock_read, mock_send):
+        """0xB6 Surplife works via the dedicated protocol (sync API)."""
+        calls = 0
+
+        def read_data(expected):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                self.assertEqual(expected, 2)
+                # 0xB6 device returns extended state format (0xEA 0x81)
+                return bytearray(b"\xea\x81")
+            if calls == 2:
+                # Extended state: 21 bytes total, first 2 already read
+                self.assertEqual(expected, 19)
+                return bytearray(
+                    b"\x01\x00\xb6\x01\x23\x61\x00\x64\x0f\x00\x00\x00\x64\x64\x00\x00\x00\x00\x83"
+                )
+
+        mock_read.side_effect = read_data
+        light = flux_led.WifiLedBulb("192.168.1.164")
+
+        assert light.color_modes == {COLOR_MODE_RGB, COLOR_MODE_DIM}
+        self.assertEqual(light.protocol, PROTOCOL_LEDENET_EXTENDED_CUSTOM)
+        self.assertEqual(light.model_num, 0xB6)
+        assert "Surplife" in light.model
+        assert light.supports_extended_custom_effects is True
+
+        # Basic function: on/off issue a standard power command.
+        mock_send.reset_mock()
+        light.turnOn()
+        assert mock_send.called
+        light.turnOff()
+        assert mock_send.called
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1480,6 +1480,7 @@ class TestLight(unittest.TestCase):
         mock_read.side_effect = read_data
         with self.assertRaisesRegex(Exception, "Cannot determine protocol"):
             flux_led.WifiLedBulb("192.168.1.199")
+
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")
     @patch("flux_led.WifiLedBulb.connect")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1480,6 +1480,78 @@ class TestLight(unittest.TestCase):
         mock_read.side_effect = read_data
         with self.assertRaisesRegex(Exception, "Cannot determine protocol"):
             flux_led.WifiLedBulb("192.168.1.199")
+    @patch("flux_led.WifiLedBulb._send_msg")
+    @patch("flux_led.WifiLedBulb._read_msg")
+    @patch("flux_led.WifiLedBulb.connect")
+    def test_0xB6_setExtendedCustomEffect(self, mock_connect, mock_read, mock_send):
+        """Test sync setExtendedCustomEffect for 0xB6 device."""
+        calls = 0
+
+        def read_data(expected):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                self.assertEqual(expected, 2)
+                return bytearray(b"\xea\x81")
+            if calls == 2:
+                self.assertEqual(expected, 19)
+                return bytearray(
+                    b"\x01\x00\xb6\x01\x23\x61\x00\x64\x0f\x00\x00\x00\x64\x64\x00\x00\x00\x00\x83"
+                )
+
+        mock_read.side_effect = read_data
+        light = flux_led.WifiLedBulb("192.168.1.164")
+
+        self.assertEqual(light.protocol, PROTOCOL_LEDENET_EXTENDED_CUSTOM)
+
+        # Call setExtendedCustomEffect
+        light.setExtendedCustomEffect(
+            pattern_id=1,
+            colors=[(255, 0, 0), (0, 255, 0)],
+            speed=50,
+            density=50,
+        )
+
+        # Verify _send_msg was called
+        assert mock_send.called
+        sent_data = mock_send.call_args[0][0]
+        # Verify it's a wrapped message
+        assert sent_data[0] == 0xB0
+        assert sent_data[1] == 0xB1
+
+    @patch("flux_led.WifiLedBulb._send_msg")
+    @patch("flux_led.WifiLedBulb._read_msg")
+    @patch("flux_led.WifiLedBulb.connect")
+    def test_0xB6_setCustomSegmentColors(self, mock_connect, mock_read, mock_send):
+        """Test sync setCustomSegmentColors for 0xB6 device."""
+        calls = 0
+
+        def read_data(expected):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                self.assertEqual(expected, 2)
+                return bytearray(b"\xea\x81")
+            if calls == 2:
+                self.assertEqual(expected, 19)
+                return bytearray(
+                    b"\x01\x00\xb6\x01\x23\x61\x00\x64\x0f\x00\x00\x00\x64\x64\x00\x00\x00\x00\x83"
+                )
+
+        mock_read.side_effect = read_data
+        light = flux_led.WifiLedBulb("192.168.1.164")
+
+        self.assertEqual(light.protocol, PROTOCOL_LEDENET_EXTENDED_CUSTOM)
+
+        # Call setCustomSegmentColors
+        light.setCustomSegmentColors(segments=[(255, 0, 0), None, (0, 0, 255)])
+
+        # Verify _send_msg was called
+        assert mock_send.called
+        sent_data = mock_send.call_args[0][0]
+        # Verify it's a wrapped message
+        assert sent_data[0] == 0xB0
+        assert sent_data[1] == 0xB1
 
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1463,6 +1463,27 @@ class TestLight(unittest.TestCase):
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")
     @patch("flux_led.WifiLedBulb.connect")
+    def test_determine_protocol_invalid_response_raises(
+        self, mock_connect, mock_read, mock_send
+    ):
+        """If no probe yields a valid (standard or extended) state, raise.
+
+        Exercises the ``not (is_valid_state_response or
+        is_valid_extended_state_response)`` branch (the extended check is the
+        0xB6 addition) and the final 'Cannot determine protocol' raise.
+        """
+
+        def read_data(expected):
+            # Non-0xEA, non-state garbage: fails both validators for every probe.
+            return bytearray(b"\x99" * expected)
+
+        mock_read.side_effect = read_data
+        with self.assertRaisesRegex(Exception, "Cannot determine protocol"):
+            flux_led.WifiLedBulb("192.168.1.199")
+
+    @patch("flux_led.WifiLedBulb._send_msg")
+    @patch("flux_led.WifiLedBulb._read_msg")
+    @patch("flux_led.WifiLedBulb.connect")
     def test_rgbcw_bulb_v9(self, mock_connect, mock_read, mock_send):
         calls = 0
 


### PR DESCRIPTION
**Merge order:** #538 → #539 → #540 → #541 → this. Draft until predecessors land.


Exposes everything in PR3/PR4 through `fluxled.py`, reusing the existing `-C`/`--custom`
scaffold.

### CLI surface
- **Extended effects:** `-C <pattern> <speed> "<colors>"` — pattern is a name (incl.
  multi-word, e.g. `"rainbow bridge"`); options `--density 0-100`, `--direction l2r|r2l`,
  `--colorchange` (= variant 1), `--variant 0|1|2`.
- **Segments:** `-C segments <speed> "<up to 20 colors>"`.
- **Scribble:** `-C scribble <effect> "<per-led-spec>"`
  - `<effect>`: a name (`static|flowing|twinkling|stars_wink|accumulate`) **or raw id `0-8`**.
  - per-LED spec tokens: `<color>`, `<n>x<color>`, `w<level>`, `off`, each with an optional
    blink suffix `…/mode[/speed]` (e.g. `40xred/fast/80`); global tokens
    `density= speed= dir= blink= blinkspeed= enter=`.
  - The CLI reconciles the spec to the device's `led_count` (pads with off / truncates, with
    a warning).
- **Timers/clock:** `-t`, `-T`, `--getclock`, `--setclock`; `--listpresets` shows the 0xB6
  effect names; help text updated for all of the above.

### Notes for review
- Color/white/effect parsing reuses `utils.color_object_to_tuple`; effect→id and
  blink-name→enum maps live next to the parser. The `w<level>` white token uses a
  digits-only regex so color names starting with `w` (e.g. `white`, `wheat`) still parse as
  colors. The per-token blink suffix uses `/` (unambiguous — colors/hex/`r,g,b` contain no
  `/`).
- Numeric effect ids are passed through as `int` to `async_set_scribble` (which accepts
  `ScribbleEffect | int`), so ids 3/4/6/7 work without a wrapping `ScribbleEffect(...)`.

### Testing
- ~694 lines of CLI tests: arg parsing for every option (extended pattern names + multi-word,
  segments, scribble effect names + numeric + range errors, per-LED blink grammar,
  `enter=`, `--variant` validation, run-length expansion, count reconcile pad/truncate).
- `pytest` green, `ruff` clean, no new `mypy` errors.

**On-device verification** (device `192.168.1.78`): the **entire** on-device test pass was
driven through this CLI (power, color/white, extended effects, segments, scribble, timers,
clock all issued via `flux_led …`). The CLI-completeness options specifically:
| Check | Command | Result |
|-------|---------|--------|
| Numeric effect id (unnamed) | `-C scribble 4 "20x255,0,0 20x0,255,0 20x0,0,255 20x255,255,0"` | ✅ animates (id 4, no UI name) |
| Per-LED blink (per-token) | `-C scribble static "40x255,0,0/fast/80 40x0,255,0"` | ✅ first half red-fast-blink, second half green-steady |
| `enter=false` | `-C scribble static "80x0,0,255 enter=false"` | ✅ renders blue, skips `E1 23` init |
| `--variant 2` | `-C "rainbow bridge" 60 "255,0,0 0,255,0 0,0,255" --variant 2` | ✅ applies (option byte 2) |

CLI coverage matrix: every device/API capability is reachable from the CLI; the only
remaining item is informational (`led_count` is not printed in `-i`).
