### PR TITLE
feat: 0xB6 E1 22 color/segment set + solid-color reporting

### DIFF
--- a/flux_led/aiodevice.py
+++ b/flux_led/aiodevice.py
@@ -422,6 +422,22 @@ class AIOWifiLedBulb(LEDENETDevice):
             self._generate_custom_patterm(rgb_list, speed, transition_type)
         )
 
+    async def async_set_custom_segment_colors(
+        self,
+        segments: list[tuple[int, int, int] | None],
+    ) -> None:
+        """Set custom colors for each segment on the device.
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+        Sets static HSV colors for each of 20 segments on the light strip.
+
+        Args:
+            segments: List of up to 20 segment colors. Each is (R, G, B) or None for off.
+        """
+        if not self.supports_extended_custom_effects:
+            raise ValueError("device does not support extended custom effects")
+        await self._async_send_msg(self._generate_custom_segment_colors(segments))
+
     async def async_set_effect(
         self, effect: str, speed: int, brightness: int = 100
     ) -> None:

--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -667,6 +667,11 @@ class LEDENETDevice:
         mode = self.raw_state.mode
         pattern_code = self.preset_pattern_num
         protocol = self.protocol
+        if self.supports_extended_custom_effects:
+            # 0xB6 "Colorful" (solid or multi-segment) reports preset_pattern=0x24;
+            # it is a plain color, not an effect (hardware-verified), so report none.
+            if pattern_code == 0x24:
+                return None
         if protocol in OLD_EFFECTS_PROTOCOLS:
             effect_id = (pattern_code << 8) + mode - 99
             return ORIGINAL_ADDRESSABLE_EFFECT_ID_NAME.get(effect_id)
@@ -1324,6 +1329,35 @@ class LEDENETDevice:
 
         assert self._protocol is not None
         return self._protocol.construct_custom_effect(rgb_list, speed, transition_type)
+
+    def _generate_custom_segment_colors(
+        self,
+        segments: list[tuple[int, int, int] | None],
+    ) -> bytearray:
+        """Generate custom segment colors protocol bytes with validation.
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+
+        Args:
+            segments: List of up to 20 segment colors. Each is (R, G, B) or None for off.
+        """
+        # Reject more than 20 segments (the wire format supports at most 20)
+        if len(segments) > 20:
+            raise ValueError(f"at most 20 segments are supported, got {len(segments)}")
+
+        # Validate color tuples
+        for idx, color in enumerate(segments):
+            if color is None:
+                continue
+            if len(color) != 3:
+                raise ValueError(f"Segment {idx} must be (R, G, B) tuple or None")
+            for c in color:
+                if not 0 <= c <= 255:
+                    raise ValueError(f"Color values must be 0-255, got {c}")
+
+        assert self._protocol is not None
+        assert isinstance(self._protocol, ProtocolLEDENETExtendedCustom)
+        return self._protocol.construct_custom_segment_colors(segments)
 
     def _effect_to_pattern(self, effect: str) -> int:
         """Convert an effect to a pattern code."""

--- a/flux_led/device.py
+++ b/flux_led/device.py
@@ -391,5 +391,27 @@ class WifiLedBulb(LEDENETDevice):
             retry=retry,
         )
 
+    def setCustomSegmentColors(
+        self,
+        segments: list[tuple[int, int, int] | None],
+        retry: int = DEFAULT_RETRIES,
+    ) -> None:
+        """Set custom colors for each segment on the device.
+
+        Only supported on devices using the extended protocol (e.g., 0xB6).
+        Sets static HSV colors for each of 20 segments on the light strip.
+
+        Args:
+            segments: List of up to 20 segment colors. Each is (R, G, B) or None for off.
+            retry: Number of retries on failure
+        """
+        if not self.supports_extended_custom_effects:
+            raise ValueError("device does not support extended custom effects")
+        self._send_and_read_with_retry(
+            self._generate_custom_segment_colors(segments),
+            0,
+            retry=retry,
+        )
+
     def refreshState(self) -> None:
         return self.update_state()

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -1680,6 +1680,132 @@ class ProtocolLEDENETExtendedCustom(ProtocolLEDENET25Byte):
             return None
         return raw_state[LEDENET_EXTENDED_STATE_LED_COUNT_POS]
 
+    def _rgb_to_hsv_bytes_rgbw(
+        self, r: int, g: int, b: int, white: int = 0
+    ) -> list[int]:
+        """Convert RGBW (0-255) to 5-byte HSVW format for extended effect commands.
+
+        Output format:
+          [H/2, S, V, 0x00, W]
+           0    1  2   3    4
+           |    |  |   |    white LED brightness (0-255)
+           |    |  |   unused (always 0x00)
+           |    |  value/brightness (0-100)
+           |    saturation (0-100)
+           hue divided by 2 (0-180)
+
+        Args:
+            r: Red component (0-255)
+            g: Green component (0-255)
+            b: Blue component (0-255)
+            white: White LED brightness (0-255)
+
+        Returns:
+            5-byte list [H/2, S, V, 0x00, W]
+        """
+        h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+        return [int(h * 180), int(s * 100), int(v * 100), 0x00, white]
+
+    def construct_levels_change(
+        self,
+        persist: int,
+        red: int | None,
+        green: int | None,
+        blue: int | None,
+        warm_white: int | None,
+        cool_white: int | None,
+        write_mode: LevelWriteMode | int,
+    ) -> list[bytearray]:
+        """Construct a level change using a uniform 0xE1 0x22 fill command.
+
+        The vendor app sets a solid color with a UNIFORM 0xE1 0x22 command (all
+        20 segments identical), which lands the device in preset_pattern=0x24
+        ("Colorful" = a plain color) and reports effect=None with the correct
+        rgb/brightness. This is hardware-verified on the 0xB6 device.
+
+        Inner message format (before wrapping):
+          pos  0  1  2  3  4  5  6  [ 5-byte segment ] x 20
+              E1 22 00 00 00 00 14  [ H/2 S V 00 WW ]
+                                 |  each of the 20 identical segments:
+                                 |    color: [H/2, S, V, 0x00, 0x00]
+                                 |    white: [0x00, 0x64, 0x00, 0x00, W]
+                                 segment count (0x14 = 20)
+
+        The device is single-white RGB and the app sends EITHER a color OR a
+        white, never both. Warm and cool white are combined into a single
+        white level.
+        """
+        # The device has a single white LED. The caller (_generate_levels_change)
+        # mirrors a single white value into BOTH warm and cool for non-CCT
+        # devices, so take the max (not the sum) to avoid double-counting it.
+        w = max(warm_white or 0, cool_white or 0)
+
+        if w > 0 and not (red or green or blue):
+            # WHITE: scale 0-255 white to the device's 0-100 white level.
+            # S byte MUST be 0x64 (100); with S=0 the device silently ignores
+            # the frame (hardware-verified).
+            white_level = max(0, min(100, round(w * 100 / 255)))
+            segment = [0x00, 0x64, 0x00, 0x00, white_level]
+        else:
+            # COLOR: [H/2, S, V, 0x00, 0x00]
+            segment = self._rgb_to_hsv_bytes((red or 0), (green or 0), (blue or 0))
+
+        # Uniform E1 22 fill: header + segment repeated for all 20 segments
+        inner = bytearray([0xE1, 0x22, 0x00, 0x00, 0x00, 0x00, 0x14])
+        for _ in range(20):
+            inner.extend(segment)
+
+        return [
+            self.construct_wrapped_message(
+                inner, inner_pre_constructed=True, version=0x02
+            )
+        ]
+
+    def _rgb_to_hsv_bytes(self, r: int, g: int, b: int) -> list[int]:
+        """Convert RGB (0-255) to 5-byte HSV format [H/2, S, V, 0, 0].
+
+        This format is used by extended commands (0xE1 0x21, 0xE1 0x22).
+
+        Equivalent to the RGBW variant with white=0, which yields the same
+        [H/2, S, V, 0x00, 0x00] layout, so delegate to avoid duplicating the
+        conversion logic.
+        """
+        return self._rgb_to_hsv_bytes_rgbw(r, g, b, 0)
+
+    def construct_custom_segment_colors(
+        self,
+        segments: list[tuple[int, int, int] | None],
+    ) -> bytearray:
+        """Construct a custom segment colors command (0xE1 0x22).
+
+        Sets static HSV colors for each of 20 segments on the light strip.
+        Used by devices like AK001-ZJ21413 (model 0xB6) under the "colorful" menu.
+
+        Protocol format:
+          e1 22 00 00 00 00 14 [H/2 S V 00 00] x 20
+
+        Args:
+            segments: List of up to 20 segment colors. Each segment is either:
+                - None or (0, 0, 0) for off
+                - (R, G, B) tuple with values 0-255
+
+        Returns:
+            Wrapped command bytearray
+        """
+        # Build inner message: header + 20 segments
+        msg = bytearray([0xE1, 0x22, 0x00, 0x00, 0x00, 0x00, 0x14])
+
+        for i in range(20):
+            segment = segments[i] if i < len(segments) else None
+            if segment and segment != (0, 0, 0):
+                msg.extend(self._rgb_to_hsv_bytes(*segment))
+            else:
+                msg.extend([0x00, 0x00, 0x00, 0x00, 0x00])  # Off
+
+        return self.construct_wrapped_message(
+            msg, inner_pre_constructed=True, version=0x02
+        )
+
 
 class ProtocolLEDENETAddressableBase(ProtocolLEDENET9Byte):
     """Base class for addressable protocols."""

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -4383,6 +4383,56 @@ async def test_setup_0xB6_surplife_real_frame(mock_aio_protocol):
     assert light.led_count == 100
 
 
+@pytest.mark.asyncio
+async def test_0xB6_colorful_solid_red_full(mock_aio_protocol):
+    """0xB6 "Colorful" solid red at full brightness is a plain color, not an effect.
+
+    Real device EA81 capture (app Colorful -> red): preset_pattern=0x24, mode=0x01
+    -> reported as a color with no effect (verified on device).
+    """
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    _transport, _protocol = await mock_aio_protocol()
+    light._aio_protocol.data_received(
+        bytes.fromhex("ea810100b60923240164f0b46464ff000500500000002002010003")
+    )
+    await task
+    assert light.model_num == 0xB6
+    assert light.effect is None
+    assert light.is_on is True
+    assert light.rgb == (255, 0, 0)
+    assert light.brightness == 255
+
+
+@pytest.mark.asyncio
+async def test_0xB6_colorful_solid_red_dim(mock_aio_protocol):
+    """0xB6 "Colorful" solid red dimmed to 30% is a plain color, not an effect.
+
+    Real device EA81 capture (app Colorful -> red @ 30%): preset_pattern=0x24,
+    mode=0x01, value byte 0x1e (30%).
+    """
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    _transport, _protocol = await mock_aio_protocol()
+    light._aio_protocol.data_received(
+        bytes.fromhex("ea810100b60923240164f0b4641eff000500500000002002010003")
+    )
+    await task
+    assert light.model_num == 0xB6
+    assert light.effect is None
+    assert light.is_on is True
+    # Clearly dimmed (well below the full-brightness value of 255).
+    assert light.brightness == 76
+
+
 def test_protocol_extended_custom_state_response_length():
     """ProtocolLEDENETExtendedCustom expects the 27-byte extended state."""
     proto = ProtocolLEDENETExtendedCustom()
@@ -4455,3 +4505,424 @@ def test_extended_state_led_count():
     # Too-short / invalid frame returns None
     assert proto.extended_state_led_count(b"\xea\x81\x01") is None
     assert proto.extended_state_led_count(b"\x00" * 27) is None
+
+
+def _inner_of(wrapped: bytearray) -> bytes:
+    """Extract the inner message from a B0B1B2B3-wrapped result.
+
+    wrapper = b0 b1 b2 b3 | 00 01 | ver | counter | len_hi len_lo | inner | cksum
+    """
+    inner_len = (wrapped[8] << 8) | wrapped[9]
+    return bytes(wrapped[10 : 10 + inner_len])
+
+
+def _h(s: str) -> bytes:
+    return bytes.fromhex(s.replace(" ", ""))
+
+
+async def _setup_scribble_light(mock_aio_protocol, led_count_byte=0x50):
+    """Set up a 0xB6 AIO light with a known led_count from state byte 18."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, _protocol = await mock_aio_protocol()
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                led_count_byte,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+    transport.reset_mock()
+    return light, transport
+
+
+def test_protocol_construct_levels_change_0xB6():
+    """Test construct_levels_change sets a color via a uniform E1 22 fill.
+
+    A solid color must land the device in preset 0x24 ("Colorful"), so it is
+    sent as a uniform E1 22 (all 20 segments identical), not an E1 21 Static
+    Fill (hardware-verified).
+    """
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test with RGB values (pure red)
+    result = proto.construct_levels_change(
+        persist=1,
+        red=255,
+        green=0,
+        blue=0,
+        warm_white=0,
+        cool_white=0,
+        write_mode=0,
+    )
+
+    assert len(result) == 1
+    msg = result[0]
+    assert isinstance(msg, bytearray)
+    # Check wrapper header
+    assert msg[0] == 0xB0
+    assert msg[1] == 0xB1
+    assert msg[2] == 0xB2
+    assert msg[3] == 0xB3
+
+    # Pin the full inner E1 22 uniform frame. This is byte-identical to the real
+    # app "Colorful -> red" packet captured from the device (inner:
+    # e1 22 00 00 00 00 14 [00 64 64 00 00] x 20).
+    inner = _inner_of(msg)
+    header = _h("e1 22 00 00 00 00 14")
+    # (255,0,0): hue 0, sat 100, val 100 -> [00 64 64 00 00]
+    red_seg = _h("00 64 64 00 00")
+    expected = header + red_seg * 20
+    assert inner == expected
+    assert len(inner) == 7 + 20 * 5
+
+
+def test_protocol_construct_levels_change_with_white():
+    """Test construct_levels_change for a white-only set.
+
+    A white-only set is sent as a uniform E1 22 with the literal white segment
+    [00 64 00 00 W], where W is the 0-100 white level (S byte MUST be 0x64).
+    """
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test with white values: warm_white=255 -> W = round(255*100/255) = 100
+    result = proto.construct_levels_change(
+        persist=1,
+        red=0,
+        green=0,
+        blue=0,
+        warm_white=255,
+        cool_white=0,
+        write_mode=0,
+    )
+
+    assert len(result) == 1
+    msg = result[0]
+    assert isinstance(msg, bytearray)
+
+    inner = _inner_of(msg)
+    header = _h("e1 22 00 00 00 00 14")
+    # W = 100 = 0x64; segment [00 64 00 00 64]
+    white_seg = _h("00 64 00 00 64")
+    expected = header + white_seg * 20
+    assert inner == expected
+    assert len(inner) == 7 + 20 * 5
+
+
+def test_protocol_construct_levels_change_white_not_doubled():
+    """A single white value mirrored into warm+cool must not be double-counted.
+
+    The device has one white LED; _generate_levels_change mirrors a single white
+    value into BOTH warm and cool for non-CCT devices, so combining them by max
+    (not sum) is required. Regression test: warm=cool=128 (a mirrored single
+    white of 128) must yield W = round(128*100/255) = 50, not 100.
+    """
+    proto = ProtocolLEDENETExtendedCustom()
+
+    result = proto.construct_levels_change(
+        persist=1,
+        red=0,
+        green=0,
+        blue=0,
+        warm_white=128,
+        cool_white=128,  # mirrored single white; max -> 128 -> W=50 (not 2x)
+        write_mode=0,
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], bytearray)
+
+    inner = _inner_of(result[0])
+    header = _h("e1 22 00 00 00 00 14")
+    white_seg = _h("00 64 00 00 32")  # W = 50 = 0x32 (not doubled to 0x64)
+    expected = header + white_seg * 20
+    assert inner == expected
+
+
+def test_protocol_rgb_to_hsv_bytes_rgbw():
+    """Test _rgb_to_hsv_bytes_rgbw conversion."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test pure red with white
+    result = proto._rgb_to_hsv_bytes_rgbw(255, 0, 0, 100)
+    assert len(result) == 5
+    assert result[0] == 0  # Hue (red = 0)
+    assert result[1] == 100  # Saturation
+    assert result[2] == 100  # Value
+    assert result[3] == 0x00  # Unused
+    assert result[4] == 100  # White
+
+    # Test pure green
+    result = proto._rgb_to_hsv_bytes_rgbw(0, 255, 0, 0)
+    assert result[0] == 60  # Hue (green = 120/2)
+
+    # Test pure blue
+    result = proto._rgb_to_hsv_bytes_rgbw(0, 0, 255, 255)
+    assert result[0] == 120  # Hue (blue = 240/2)
+    assert result[4] == 255  # White
+
+
+def test_protocol_construct_custom_segment_colors():
+    """Test construct_custom_segment_colors command format."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Test with a few segments
+    segments = [(255, 0, 0), None, (0, 0, 255)]
+    result = proto.construct_custom_segment_colors(segments)
+
+    assert isinstance(result, bytearray)
+    # Check wrapper header
+    assert result[0] == 0xB0
+    assert result[1] == 0xB1
+    assert result[2] == 0xB2
+    assert result[3] == 0xB3
+
+    # Pin the full inner E1 22 payload: header + 0x14 (20) count byte, then
+    # one 5-byte [H/2, S, V, 0x00, 0x00] record per segment, padded to 20.
+    inner = _inner_of(result)
+    header = _h("e1 22 00 00 00 00 14")
+    red = _h("00 64 64 00 00")  # (255,0,0): hue 0, sat 100, val 100
+    off = _h("00 00 00 00 00")  # None / off segment
+    blue = _h("78 64 64 00 00")  # (0,0,255): hue 240 -> H/2 = 0x78, sat/val 100
+    # 3 provided segments (red, off, blue) + 17 off segments = 20 total.
+    expected = header + red + off + blue + off * 17
+    assert inner == expected
+    assert len(inner) == 7 + 20 * 5
+
+
+def test_protocol_construct_custom_segment_colors_rgb_captured():
+    """Per-segment RGB encodings, anchored to the 2026-07-02 device capture.
+
+    From the vendor app "Colorful" segment paint (hardware-verified): red, green
+    and blue segments encode as the exact H/2 hue bytes below (green = 0x3c,
+    blue = 0x78), in the same 20-segment E1 22 command used for a single color.
+    See docs/device_testing_0xB6.md.
+    """
+    proto = ProtocolLEDENETExtendedCustom()
+
+    segments = [(255, 0, 0), (0, 255, 0), (0, 0, 255)]
+    result = proto.construct_custom_segment_colors(segments)
+
+    inner = _inner_of(result)
+    header = _h("e1 22 00 00 00 00 14")
+    red = _h("00 64 64 00 00")  # hue 0
+    green = _h("3c 64 64 00 00")  # hue 120 -> H/2 = 0x3c
+    blue = _h("78 64 64 00 00")  # hue 240 -> H/2 = 0x78
+    off = _h("00 00 00 00 00")
+    expected = header + red + green + blue + off * 17
+    assert inner == expected
+    assert len(inner) == 7 + 20 * 5
+
+
+def test_protocol_construct_custom_segment_colors_all_off():
+    """Test construct_custom_segment_colors with all segments off."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # All None segments
+    segments = [None] * 10
+    result = proto.construct_custom_segment_colors(segments)
+
+    assert isinstance(result, bytearray)
+
+
+def test_protocol_construct_custom_segment_colors_zero_tuple():
+    """Test that (0,0,0) is treated as off."""
+    proto = ProtocolLEDENETExtendedCustom()
+
+    # Mix of None and (0,0,0)
+    segments = [None, (0, 0, 0), (255, 0, 0)]
+    result = proto.construct_custom_segment_colors(segments)
+
+    assert isinstance(result, bytearray)
+
+
+@pytest.mark.asyncio
+async def test_async_set_custom_segment_colors_0xB6(mock_aio_protocol):
+    """Test async_set_custom_segment_colors sends correct bytes."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    transport, _protocol = await mock_aio_protocol()
+
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    transport.reset_mock()
+
+    await light.async_set_custom_segment_colors(
+        segments=[(255, 0, 0), None, (0, 0, 255)]
+    )
+
+    assert transport.write.called
+    written_data = transport.write.call_args[0][0]
+    # Verify it's a wrapped message
+    assert written_data[0] == 0xB0
+    assert written_data[1] == 0xB1
+
+
+@pytest.mark.asyncio
+async def test_generate_custom_segment_colors_validation(mock_aio_protocol):
+    """Test validation in _generate_custom_segment_colors."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    await mock_aio_protocol()
+
+    light._aio_protocol.data_received(
+        bytes(
+            (
+                0xEA,
+                0x81,
+                0x01,
+                0x00,
+                0xB6,
+                0x01,
+                0x23,
+                0x61,
+                0x24,
+                0x64,
+                0x0F,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x83,
+            )
+        )
+    )
+    await task
+
+    # Test invalid color tuple (not 3 elements)
+    with pytest.raises(ValueError, match=r"must be .* tuple"):
+        light._generate_custom_segment_colors([(255, 0)])
+
+    # Test color values out of range (> 255)
+    with pytest.raises(ValueError, match="must be 0-255"):
+        light._generate_custom_segment_colors([(256, 0, 0)])
+
+    # Test valid segments with None
+    result = light._generate_custom_segment_colors([None, (255, 0, 0), None])
+    assert isinstance(result, bytearray)
+
+
+@pytest.mark.asyncio
+async def test_generate_custom_segment_colors_rejects_too_many_segments(
+    mock_aio_protocol,
+):
+    """Test that too many segments (>20) raise ValueError instead of truncating."""
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+
+    # 21 segments (one over the 20 max) must raise; 20 is still accepted.
+    segments = [(i * 10, 0, 0) for i in range(21)]
+    with pytest.raises(ValueError, match="at most 20 segments are supported, got 21"):
+        light._generate_custom_segment_colors(segments)
+
+    result = light._generate_custom_segment_colors(segments[:20])
+    assert isinstance(result, bytearray)
+
+
+@pytest.mark.parametrize(
+    "segments, match",
+    [
+        # color tuple wrong length
+        ([(255, 0)], r"must be .* tuple"),
+        # color channel out of 0-255 (high)
+        ([(256, 0, 0)], "must be 0-255"),
+        # color channel out of 0-255 (low)
+        ([(0, -1, 0)], "must be 0-255"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_generate_custom_segment_colors_color_guards(
+    mock_aio_protocol, segments, match
+):
+    """Cover the color-tuple ValueError guards in _generate_custom_segment_colors."""
+    light, _t = await _setup_scribble_light(mock_aio_protocol)
+    with pytest.raises(ValueError, match=match):
+        light._generate_custom_segment_colors(segments)
+
+
+@pytest.mark.asyncio
+async def test_async_extended_custom_methods_raise_on_unsupported_device(
+    mock_aio_protocol,
+):
+    """Async extended-custom methods raise ValueError on a non-0xB6 device."""
+    light = AIOWifiLedBulb("192.168.1.166")
+
+    def _updated_callback(*args, **kwargs):
+        pass
+
+    task = asyncio.create_task(light.async_setup(_updated_callback))
+    _transport, _protocol = await mock_aio_protocol()
+    # Standard RGBCW bulb (0x35) -- does not use the extended custom protocol.
+    light._aio_protocol.data_received(
+        b"\x81\x35\x23\x61\x05\x10\xb6\x00\x98\x19\x04\x25\x0f\xee"
+    )
+    await task
+    assert light.model_num == 0x35
+    assert not light.supports_extended_custom_effects
+
+    with pytest.raises(ValueError):
+        await light.async_set_custom_segment_colors([(255, 0, 0)])

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1487,6 +1487,78 @@ class TestLight(unittest.TestCase):
     @patch("flux_led.WifiLedBulb._send_msg")
     @patch("flux_led.WifiLedBulb._read_msg")
     @patch("flux_led.WifiLedBulb.connect")
+    def test_0xB6_setCustomSegmentColors(self, mock_connect, mock_read, mock_send):
+        """Test sync setCustomSegmentColors for 0xB6 device."""
+        calls = 0
+
+        def read_data(expected):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                self.assertEqual(expected, 2)
+                return bytearray(b"\xea\x81")
+            if calls == 2:
+                self.assertEqual(expected, 25)
+                return bytearray(
+                    b"\x01\x00\xb6\x09\x24\x66\x01\x64\xf0\x00\x00\x00\x00\x64\x05\x00\x64\x00\x00\x00\x20\x02\x01\x00\x03"
+                )
+
+        mock_read.side_effect = read_data
+        light = flux_led.WifiLedBulb("192.168.1.164")
+
+        self.assertEqual(light.protocol, PROTOCOL_LEDENET_EXTENDED_CUSTOM)
+
+        # Call setCustomSegmentColors
+        light.setCustomSegmentColors(segments=[(255, 0, 0), None, (0, 0, 255)])
+
+        # Verify _send_msg was called
+        assert mock_send.called
+        sent_data = mock_send.call_args[0][0]
+        # Verify it's a wrapped message
+        assert sent_data[0] == 0xB0
+        assert sent_data[1] == 0xB1
+
+    @patch("flux_led.WifiLedBulb._send_msg")
+    @patch("flux_led.WifiLedBulb._read_msg")
+    @patch("flux_led.WifiLedBulb.connect")
+    def test_0xB6_methods_raise_on_unsupported_device(
+        self, mock_connect, mock_read, mock_send
+    ):
+        """Sync extended-custom methods raise ValueError on a non-0xB6 device."""
+        calls = 0
+
+        def read_data(expected):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                self.assertEqual(expected, 2)
+                return bytearray(b"\x81\x35")
+            if calls == 2:
+                self.assertEqual(expected, 12)
+                return bytearray(b"\x23\x61\x05\x10\xb6\x00\x98\x00\x09\x00\xf0\x96")
+            if calls == 3:
+                self.assertEqual(expected, 14)
+                return bytearray(
+                    b"\x81\x35\x23\x61\x05\x10\xb6\x00\x98\x19\x09\x25\x0f\xf3"
+                )
+            if calls == 4:
+                self.assertEqual(expected, 14)
+                return bytearray(
+                    b"\x81\x35\x23\x38\x05\x10\xb6\x00\x98\x19\x09\x25\x0f\xca"
+                )
+
+        mock_read.side_effect = read_data
+        light = flux_led.WifiLedBulb("192.168.1.164")
+        # Standard RGBCW bulb -- does not use the extended custom protocol.
+        self.assertEqual(light.protocol, PROTOCOL_LEDENET_9BYTE_DIMMABLE_EFFECTS)
+        assert not light.supports_extended_custom_effects
+
+        with self.assertRaises(ValueError):
+            light.setCustomSegmentColors(segments=[(255, 0, 0)])
+
+    @patch("flux_led.WifiLedBulb._send_msg")
+    @patch("flux_led.WifiLedBulb._read_msg")
+    @patch("flux_led.WifiLedBulb.connect")
     def test_rgbcw_bulb_v9(self, mock_connect, mock_read, mock_send):
         calls = 0
 


### PR DESCRIPTION
## Summary

First of a stacked series splitting the large 0xB6 effects work (#540) into reviewable PRs. This PR adds **only** the E1 22 color/segment path and solid-color reporting for the 0xB6 (Surplife) extended-custom protocol. The extended custom effects (E1 21) and scribble (E1 23/E1 26) features land in follow-up PRs stacked on top of this one.

## What's included

- **protocol.py**
  - `construct_levels_change` rewritten as a uniform E1 22 fill so a plain color lands the device in preset `0x24` ("Colorful", `effect=None`) rather than an E1 21 Static Fill scene (hardware-verified).
  - Single white is combined by `max` (not sum) to avoid double-counting the mirrored warm/cool channel on this single-white-LED device.
  - Add `_rgb_to_hsv_bytes` / `_rgb_to_hsv_bytes_rgbw` helpers and `construct_custom_segment_colors`.
- **base_device.py**
  - `_named_effect` reports preset `0x24` as a plain color (no effect).
  - Add `_generate_custom_segment_colors` with validation.
- **device.py / aiodevice.py**
  - Add `setCustomSegmentColors` / `async_set_custom_segment_colors`.
- **tests**
  - Sync + aio coverage for solid-color reporting, level-change framing (color, white, white-not-doubled), RGBW HSV conversion, segment-color construction/validation, and the unsupported-device guard.

`const.py` and `pattern.py` are untouched.

## Verification

All gates pass locally:

- `pytest -q` — 169 passed
- `ruff check flux_led/ tests/` — clean
- `ruff format --check flux_led/ tests/` — clean
- `mypy --python-version=3.13 flux_led/*.py` — clean
- `mypy --python-version=3.10 flux_led/*.py` — clean

## Stack

This is PR 1 of 3 (colors -> extended effects -> scribble).